### PR TITLE
Spinner component was throwing an error if it was created and delete …

### DIFF
--- a/Source/Lib/mdl/Spinner.js
+++ b/Source/Lib/mdl/Spinner.js
@@ -59,6 +59,9 @@ class Spinner extends Component {
 
   componentDidMount() {
     requestAnimationFrame(() => {
+      if (this.refs.container == null) {
++        return;
++     }
       const container = this.refs.container.refs.node;  // un-box animated view
       container.measure((left, top, width, height) => {
         this.setState({dimen: {width, height}}, () => this._aniUpdateSpinner());


### PR DESCRIPTION
…quickly

By the the time the requestAnimationFrame callback is called the component may have been removed and the refs may be undefined.