### PR TITLE
Adding pod spec. closes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ First, `cd` to your RN project directory, and install RNMK through the command `
 1. Add `node_modules/react-native-material-kit/iOS/RCTMaterialKit.xcodeproj` to your xcode project, usually under the `Libraries` group
 1. Add `libRCTMaterialKit.a` (from `Products` under `RCTMaterialKit.xcodeproj`) to build target's `Linked Frameworks and Libraries` list
 
+#### Option: Using [CocoaPods](https://cocoapods.org)
+
+Assuming you have [CocoaPods](https://cocoapods.org) installed, create a `PodFile` like this in your app's project directory. You can leave out the modules you don't need.
+
+```ruby
+xcodeproj 'path/to/YourProject.xcodeproj/'
+
+pod 'React', :subspecs => ['Core', 'RCTText', 'RCTWebSocket'], :path => 'node_modules/react-native'
+pod 'react-native-material-kit', :path => 'node_modules/react-native-material-kit'
+
+post_install do |installer|
+  target = installer.pods_project.targets.select{|t| 'React' == t.name}.first
+  phase = target.new_shell_script_build_phase('Run Script')
+  phase.shell_script = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -s \"http://localhost:8081/status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open $SRCROOT/../node_modules/react-native/packager/launchPackager.command || echo \"Can't start packager automatically\"\nfi"
+end
+```
+
+Now run `pod install`. This will create an Xcode workspace containing all necessary native files, including react-native-material-kit. From now on open `YourProject.xcworkspace` instead of `YourProject.xcodeproject` in Xcode. Because React Native's iOS code is now pulled in via CocoaPods, you also need to remove the `React`, `RCTImage`, etc. subprojects from your app's Xcode project, in case they were added previously.
+
 ### Android
 1. Add the following snippet to your `android/settings.gradle`:
   ```gradle

--- a/react-native-material-kit.podspec
+++ b/react-native-material-kit.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "react-native-material-kit"
+  s.version      = "0.2.0-SNAPSHOT"
+  s.summary      = "Introducing Material Design to apps built with React Native."
+  s.requires_arc = true
+  s.author       = { 'xinthink' => 'yingxinwu.g@gmail.com' }
+  s.license      = 'MIT'
+  s.homepage     = 'n/a'
+  s.source       = { :git => "https://github.com/xinthink/react-native-material-kit.git" }
+  s.source_files = 'iOS/RCTMaterialKit/*'
+  s.platform     = :ios, "7.0"
+  s.dependency 'React'
+end


### PR DESCRIPTION
adding pod spec to the project so installing the project in a cocoapods react native project should be as simple as:

```ruby
pod 'react-native-material-kit', :path => 'node_modules/react-native-material-kit'
```

full example:
```ruby
xcodeproj 'ios/Example.xcodeproj/'

pod 'React', :subspecs => ['Core', 'RCTText', 'RCTWebSocket'], :path => 'node_modules/react-native'
pod 'react-native-material-kit', :path => 'node_modules/react-native-material-kit'

post_install do |installer|
  target = installer.pods_project.targets.select{|t| 'React' == t.name}.first
  phase = target.new_shell_script_build_phase('Run Script')
  phase.shell_script = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -s \"http://localhost:8081/status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open $SRCROOT/../node_modules/react-native/packager/launchPackager.command || echo \"Can't start packager automatically\"\nfi"
end
```