### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Now run `pod install`. This will create an Xcode workspace containing all necess
 
   ```
 1. Add `compile project(':RNMaterialKit')` to your `android/app/build.gradle`
+1. Add `import com.github.xinthink.rnmk.ReactMaterialKitPackage; ` in `MainActivity.java` imports 
 1. Add `ReactMaterialKitPackage` to your `ReactInstanceManager` instance, in your `MainActivity`:
   ```java
   mReactInstanceManager = ReactInstanceManager.builder()


### PR DESCRIPTION
Added instructions to import ReactMaterialKitPackage, useful for who don't use Android Studio (or other IDE) to see "code insights", and must import it before try to addPackage(new ReactMaterialKitPackage())