### PR TITLE
Border doesn't show up when width is 0.

### DIFF
--- a/lib/mdl/cards/styles.js
+++ b/lib/mdl/cards/styles.js
@@ -10,6 +10,8 @@ var style = StyleSheet.create({
     flex : 1,
     backgroundColor: "#ffffff",
     borderRadius: 2,
+    borderColor: "#ffffff",
+    borderWidth: 1,
 
     shadowColor: "rgba(0,0,0,.12)",
     shadowOpacity: 0.8,


### PR DESCRIPTION
Fixed by setting width to 1, and borderColor same as background.