### PR TITLE
Revert to buildToolsVersion '23.0.1'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Revert to buildToolsVersion '23.0.1' to fix xinthink/react-native-material-kit#77