### PR TITLE
Fixes disappearing floating label

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -312,7 +312,7 @@ class Textfield extends Component {
 
   componentWillReceiveProps(nextProps) {
     this.bufferedValue = nextProps.value || nextProps.text ||
-      nextProps.defaultValue;
+      nextProps.defaultValue || this.bufferedValue;
     this._originPlaceholder = nextProps.placeholder;
   }
 


### PR DESCRIPTION
I’m using the previous buffered value as a fall back if new props do
not have a value.