### PR TITLE
Improve floating label animations

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -144,12 +144,12 @@ class FloatingLabel extends Component {
           backgroundColor: MKColor.Transparent,
           position: 'absolute',
           top: labelY,
+          left: labelX,
           color: labelColor,
           opacity: this.state.opacity,
           fontSize: 16,
           transform: [
             {scale: labelScale},
-            {translateX: labelX},
           ],
           marginBottom: this.props.floatingLabelBottomMargin,
         },

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -67,6 +67,10 @@ class FloatingLabel extends Component {
       this.offsetX = ((width - (width * 0.8)) / 2 * -1) - x;
     }
 
+    if (height && !this.placeholderHeight) {
+      this.placeholderHeight = height;
+    }
+
     if (width !== this.labelDim.width || height !== this.labelDim.height) {
       this.labelDim = {width, height};
     }
@@ -124,7 +128,7 @@ class FloatingLabel extends Component {
 
     let labelY = this.state.progress.interpolate({
       inputRange: [0, 1],
-      outputRange: [0, this.labelDim.height],
+      outputRange: [0, this.placeholderHeight],
     });
 
     let labelX = this.state.progress.interpolate({

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -23,7 +23,7 @@ const {
 const MKPropTypes = require('../MKPropTypes');
 const MKColor = require('../MKColor');
 const utils = require('../utils');
-const { getTheme } = require('../theme');
+const {getTheme} = require('../theme');
 import {
   pick,
 } from 'ramda';
@@ -36,11 +36,10 @@ class FloatingLabel extends Component {
   constructor(props) {
     super(props);
     this.labelDim = {};
-    this.labelState = {
-      opacity: new Animated.Value(0),
-      top: new Animated.Value(0),
-    };
+    this.offsetX = 0;
     this.state = {
+      progress: new Animated.Value(1),
+      opacity: new Animated.Value(0),
       text: '',
     };
   }
@@ -53,16 +52,8 @@ class FloatingLabel extends Component {
     this.updateText(nextProps.text);
   }
 
-  // property initializers begin
-  _onLabelLayout = ({ nativeEvent: { layout: { width, height } } }) => {
-    if (width !== this.labelDim.width || height !== this.labelDim.height) {
-      this.labelDim = { width, height };
-    }
-  };
-  // property initializers end
-
   updateText(text) {
-    this.setState({ text });
+    this.setState({text});
   }
 
   measure(cb) {
@@ -71,13 +62,19 @@ class FloatingLabel extends Component {
     }
   }
 
+  _onLabelLayout({nativeEvent: {layout: {x, y, width, height}}}) {
+    if (width && !this.offsetX) {
+      this.offsetX = ((width - (width * 0.8)) / 2 * -1) - x;
+    }
+
+    if (width !== this.labelDim.width || height !== this.labelDim.height) {
+      this.labelDim = {width, height};
+    }
+  }
+
   setColor(color) {
     // color has to be wrapped into the style object since RN 0.13
-    this.refs.label.setNativeProps({
-      style: {
-        color: utils.parseColor(color),
-      },
-    });
+    this.refs.label.setNativeProps({style:{color: utils.parseColor(color)}});
   }
 
   aniFloatLabel() {
@@ -85,13 +82,12 @@ class FloatingLabel extends Component {
       return [];
     }
 
-    this.setColor(this.props.highlightColor);
     return [Animated.sequence([
-      Animated.timing(this.labelState.opacity, {
+      Animated.timing(this.state.opacity, {
         toValue: 1,
         duration: this.props.opacityAniDur,
       }),
-      Animated.timing(this.labelState.top, {
+      Animated.timing(this.state.progress, {
         toValue: 0,
         duration: this.props.floatingLabelAniDuration,
       }),
@@ -103,13 +99,12 @@ class FloatingLabel extends Component {
       return [];
     }
 
-    this.setColor(this.props.tintColor);
     return [Animated.sequence([
-      Animated.timing(this.labelState.top, {
-        toValue: this.labelDim.height + 5,
+      Animated.timing(this.state.progress, {
+        toValue: 1,
         duration: this.props.floatingLabelAniDuration,
       }),
-      Animated.timing(this.labelState.opacity, {
+      Animated.timing(this.state.opacity, {
         toValue: 0,
         duration: this.props.opacityAniDur,
       }),
@@ -117,21 +112,46 @@ class FloatingLabel extends Component {
   }
 
   render() {
+    let labelColor = this.state.progress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [this.props.highlightColor, this.props.tintColor],
+    });
+
+    let labelScale = this.state.progress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0.8, 1],
+    });
+
+    let labelY = this.state.progress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, this.labelDim.height],
+    });
+
+    let labelX = this.state.progress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [this.offsetX, 0],
+    });
+
     return (
       <Animated.Text
         ref="label"
         pointerEvents="none"
-        style={[
-          {
-            backgroundColor: MKColor.Transparent,
-            position: 'absolute',
-            top: this.labelState.top,
-            opacity: this.labelState.opacity,
-            marginBottom: this.props.floatingLabelBottomMargin,
-          },
-          this.props.floatingLabelFont,
+        style={[{
+          backgroundColor: MKColor.Transparent,
+          position: 'absolute',
+          top: labelY,
+          color: labelColor,
+          opacity: this.state.opacity,
+          fontSize: 16,
+          transform: [
+            {scale: labelScale},
+            {translateX: labelX},
+          ],
+          marginBottom: this.props.floatingLabelBottomMargin,
+        },
+        this.props.floatingLabelFont,
         ]}
-        onLayout={this._onLabelLayout}
+        onLayout={this._onLabelLayout.bind(this)}
       >
         {this.state.text}
       </Animated.Text>
@@ -166,7 +186,7 @@ FloatingLabel.propTypes = {
 
 FloatingLabel.defaultProps = {
   floatingLabelAniDuration: 200,
-  opacityAniDur: 30,
+  opacityAniDur: 0,
 };
 
 
@@ -186,7 +206,7 @@ class Underline extends Component {
 
   // update the length of stretched underline
   updateLineLength(lineLength, cb) {
-    this.setState({ lineLength }, cb);
+    this.setState({lineLength}, cb);
   }
 
   // stretch the line, from center
@@ -230,7 +250,7 @@ class Underline extends Component {
     return (
       <View pointerEvents="none"
         style={{
-          // top: -this.props.underlineSize,
+          //top: -this.props.underlineSize,
           height: this.props.underlineSize,
         }}
       >
@@ -255,7 +275,7 @@ class Underline extends Component {
                   width: this.animatedLineLength,
                 }}
               />
-            );
+              );
           }
         })()}
       </View>
@@ -290,6 +310,7 @@ class Textfield extends Component {
     super(props);
     this.theme = getTheme();
     this.inputFrame = {};
+    this.anim = null;
     this.state = {
       inputMarginTop: 0,
     };
@@ -317,11 +338,7 @@ class Textfield extends Component {
   componentWillMount() {
     this.bufferedValue = this.props.value || this.props.text ||
       this.props.defaultValue;
-    this._originPlaceholder = this.props.placeholder;
-  }
-
-  componentDidMount() {
-    requestAnimationFrame(this._doMeasurement.bind(this));
+      this._originPlaceholder = this.props.placeholder;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -332,23 +349,17 @@ class Textfield extends Component {
     this._originPlaceholder = nextProps.placeholder;
   }
 
-  // property initializers begin
-  _onTextChange = (text) => {
-    this.bufferedValue = text;
-    this._callback('onTextChange', text);
-    this._callback('onChangeText', text);
-  };
+  componentDidMount() {
+    requestAnimationFrame(this._doMeasurement.bind(this));
+  }
 
-  _onFocus = (e) => {
-    this._aniStartHighlight(true);
-    this._callback('onFocus', e);
-  };
+  startAnimations (animations, cb) {
+    if (this.anim) {
+      this.anim.stop();
+    }
 
-  _onBlur = (e) => {
-    this._aniStopHighlight();
-    this._callback('onBlur', e);
-  };
-  // property initializers end
+    this.anim = Animated.parallel(animations).start(cb);
+  }
 
   _doMeasurement() {
     if (this.refs.input) {
@@ -360,11 +371,11 @@ class Textfield extends Component {
   }
 
   _onLabelMeasured(left, top, width, height) {
-    this.setState({ inputMarginTop: height });
+    this.setState({inputMarginTop: height});
   }
 
   _onInputMeasured(left, top, width, height) {
-    Object.assign(this.inputFrame, { left, top, width, height });
+    Object.assign(this.inputFrame, {left, top, width, height});
     this.refs.underline.updateLineLength(width, () => {
       if (this.bufferedValue || this.isFocused()) {
         this._aniStartHighlight(this.isFocused());  // if input not empty, lift the label
@@ -380,7 +391,7 @@ class Textfield extends Component {
     if (this.refs.floatingLabel) {
       const animations = this.refs.floatingLabel.aniFloatLabel();
       if (animations.length) {
-        Animated.parallel(animations).start();
+        this.startAnimations(animations);
       }
     }
   }
@@ -405,7 +416,7 @@ class Textfield extends Component {
     }
 
     if (animations.length) {
-      Animated.parallel(animations).start();
+      this.startAnimations(animations);
     }
   }
 
@@ -421,7 +432,7 @@ class Textfield extends Component {
     }
 
     if (animations.length) {
-      Animated.parallel(animations).start(() => {
+      this.startAnimations(animations, () => {
         if (this.props.floatingLabelEnabled) {
           // then show fixed placeholder
           this.setPlaceholder(this._originPlaceholder);
@@ -437,7 +448,23 @@ class Textfield extends Component {
   }
 
   setPlaceholder(placeholder) {
-    this.refs.input.setNativeProps({ placeholder });
+    this.refs.input.setNativeProps({placeholder});
+  }
+
+  _onTextChange(text) {
+    this.bufferedValue = text;
+    this._callback('onTextChange', text);
+    this._callback('onChangeText', text);
+  }
+
+  _onFocus(e) {
+    this._aniStartHighlight(true);
+    this._callback('onFocus', e);
+  }
+
+  _onBlur(e) {
+    this._aniStopHighlight();
+    this._callback('onBlur', e);
   }
 
   _callback(name, e) {
@@ -455,49 +482,49 @@ class Textfield extends Component {
         pick(['tintColor', 'highlightColor', 'floatingLabelFont'], tfTheme),
         utils.extractProps(this, FloatingLabel.propTypes));
 
-      floatingLabel = (
-        <FloatingLabel ref="floatingLabel"
-          {...props}
-          text={this.props.placeholder}
-        />
-      );
+        floatingLabel = (
+          <FloatingLabel ref="floatingLabel"
+            {...props}
+            text={this.props.placeholder}
+          />
+        );
     }
 
     const underlineProps = Object.assign(
       pick(['tintColor', 'highlightColor'], tfTheme),
       utils.extractProps(this, ['tintColor',
-        'highlightColor', 'underlineSize', 'underlineEnabled']));
-    const inputProps = utils.extractProps(this, {
-      ...TextInput.propTypes,
-      password: 1,
-    });
+                         'highlightColor', 'underlineSize', 'underlineEnabled']));
+                         const inputProps = utils.extractProps(this, {
+                           ...TextInput.propTypes,
+                           password: 1,
+                         });
 
-    return (
-      <View style={this.props.style} >
-        <TextInput  // the input
-          ref="input"
-          {...inputProps}
-          style={[{
-            backgroundColor: MKColor.Transparent,
-            flex: 1,
-            alignSelf: 'stretch',
-            paddingTop: 2, paddingBottom: 2,
-            marginTop: this.state.inputMarginTop,
-          },
-          this.theme.textfieldStyle.textInputStyle,
-          this.props.textInputStyle,
-          ]}
-          onChangeText={this._onTextChange}
-          onFocus={this._onFocus}
-          onBlur={this._onBlur}
-        />
-        {floatingLabel}
-        <Underline ref="underline"  // the underline
-          {...underlineProps}
-          underlineAniDur={this.props.floatingLabelAniDuration}
-        />
-      </View>
-    );
+                         return (
+                           <View style={this.props.style} >
+                             <TextInput  // the input
+                               ref="input"
+                               {...inputProps}
+                               style={[{
+                                 backgroundColor: MKColor.Transparent,
+                                 flex: 1,
+                                 alignSelf: 'stretch',
+                                 paddingTop: 2, paddingBottom: 2,
+                                 marginTop: this.state.inputMarginTop,
+                               },
+                               this.theme.textfieldStyle.textInputStyle,
+                               this.props.textInputStyle,
+                               ]}
+                               onChangeText={this._onTextChange.bind(this)}
+                               onFocus={this._onFocus.bind(this)}
+                               onBlur={this._onBlur.bind(this)}
+                             />
+                             {floatingLabel}
+                             <Underline ref="underline"  // the underline
+                               {...underlineProps}
+                               underlineAniDur={this.props.floatingLabelAniDuration}
+                             />
+                           </View>
+                         );
   }
 }
 
@@ -538,9 +565,20 @@ Textfield.propTypes = {
 
 // ## <section id='defaults'>Defaults</section>
 Textfield.defaultProps = {
+  //tintColor: 'rgba(0,0,0,.12)',
+  //highlightColor: getTheme().primaryColor,
+  //floatingLabelFont: {
+  //  fontSize: getTheme().fontSize - 2,
+  //},
   style: {
     height: 39,
   },
+  //textInputStyle: {
+  //  color: getTheme().fontColor,
+  //  fontSize: getTheme().fontSize + 2,
+  //  paddingLeft: 0,
+  //  paddingRight: 0,
+  //},
   underlineEnabled: true,
 };
 

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -482,49 +482,49 @@ class Textfield extends Component {
         pick(['tintColor', 'highlightColor', 'floatingLabelFont'], tfTheme),
         utils.extractProps(this, FloatingLabel.propTypes));
 
-        floatingLabel = (
-          <FloatingLabel ref="floatingLabel"
-            {...props}
-            text={this.props.placeholder}
-          />
-        );
+      floatingLabel = (
+        <FloatingLabel ref="floatingLabel"
+          {...props}
+          text={this.props.placeholder}
+        />
+      );
     }
 
     const underlineProps = Object.assign(
       pick(['tintColor', 'highlightColor'], tfTheme),
       utils.extractProps(this, ['tintColor',
-                         'highlightColor', 'underlineSize', 'underlineEnabled']));
-                         const inputProps = utils.extractProps(this, {
-                           ...TextInput.propTypes,
-                           password: 1,
-                         });
+        'highlightColor', 'underlineSize', 'underlineEnabled']));
+    const inputProps = utils.extractProps(this, {
+      ...TextInput.propTypes,
+      password: 1,
+    });
 
-                         return (
-                           <View style={this.props.style} >
-                             <TextInput  // the input
-                               ref="input"
-                               {...inputProps}
-                               style={[{
-                                 backgroundColor: MKColor.Transparent,
-                                 flex: 1,
-                                 alignSelf: 'stretch',
-                                 paddingTop: 2, paddingBottom: 2,
-                                 marginTop: this.state.inputMarginTop,
-                               },
-                               this.theme.textfieldStyle.textInputStyle,
-                               this.props.textInputStyle,
-                               ]}
-                               onChangeText={this._onTextChange.bind(this)}
-                               onFocus={this._onFocus.bind(this)}
-                               onBlur={this._onBlur.bind(this)}
-                             />
-                             {floatingLabel}
-                             <Underline ref="underline"  // the underline
-                               {...underlineProps}
-                               underlineAniDur={this.props.floatingLabelAniDuration}
-                             />
-                           </View>
-                         );
+    return (
+      <View style={this.props.style} >
+        <TextInput  // the input
+          ref="input"
+          {...inputProps}
+          style={[{
+            backgroundColor: MKColor.Transparent,
+            flex: 1,
+            alignSelf: 'stretch',
+            paddingTop: 2, paddingBottom: 2,
+            marginTop: this.state.inputMarginTop,
+          },
+          this.theme.textfieldStyle.textInputStyle,
+          this.props.textInputStyle,
+          ]}
+          onChangeText={this._onTextChange.bind(this)}
+          onFocus={this._onFocus.bind(this)}
+          onBlur={this._onBlur.bind(this)}
+        />
+        {floatingLabel}
+        <Underline ref="underline"  // the underline
+          {...underlineProps}
+          underlineAniDur={this.props.floatingLabelAniDuration}
+        />
+      </View>
+    );
   }
 }
 

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -12,7 +12,7 @@ class AttrReference {
   }
 
   get value() {
-    return theme[this.attr]
+    return theme[this.attr];
   }
 }
 
@@ -158,7 +158,7 @@ function isPlainObject(o) {
 function wrapAttrRef(style, attr, attrValue) {
   Object.defineProperty(style, attr, {
     enumerable: true,
-    get: function () {
+    get () {
       return attrValue.value;
     },
   });

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -4,21 +4,18 @@
 //
 const MKColor = require('./MKColor');
 
-// Declaration of the global theme object.
 let theme;
 
-// Reference to another style attribute, for style inheritance
 class AttrReference {
   constructor(attr) {
     this.attr = attr;
   }
 
   get value() {
-    return theme[this.attr];
+    return theme[this.attr]
   }
 }
 
-// AttrReference for rgb(a) colors
 class RGBAttrReference extends AttrReference {
   constructor(attr, alpha) {
     super(attr);
@@ -31,7 +28,6 @@ class RGBAttrReference extends AttrReference {
   }
 }
 
-// Pre-defined attr references
 const primaryColorRef = new AttrReference('primaryColor');
 const accentColorRef = new AttrReference('accentColor');
 
@@ -50,7 +46,7 @@ theme = {
   rippleColor: 'rgba(255,255,255,.125)',
   textfieldStyle: {
     tintColor: 'rgba(0,0,0,.12)',
-    highlightColor: primaryColorRef,
+    highlightColor: new RGBAttrReference('primaryColorRGB', 0.9),
     textInputStyle: {
       color: new AttrReference('fontColor'),
       fontSize: 16,
@@ -58,14 +54,14 @@ theme = {
       paddingRight: 0,
     },
     floatingLabelFont: {
-      fontSize: 12,
+      fontSize: 16,
       color: 'red',
     },
   },
   progressStyle: {
-    backgroundColor: new RGBAttrReference('primaryColorRGB', 0.3),
+    backgroundColor: new RGBAttrReference('primaryColorRGB', .3),
     progressColor: primaryColorRef,
-    bufferColor: new RGBAttrReference('primaryColorRGB', 0.3),
+    bufferColor: new RGBAttrReference('primaryColorRGB', .3),
   },
   spinnerStyle: {
     strokeColor: [
@@ -80,28 +76,28 @@ theme = {
     upperTrackColor: '#cccccc',
   },
   iconToggleStyle: {
-    onColor: new RGBAttrReference('primaryColorRGB', 0.4),
+    onColor: new RGBAttrReference('primaryColorRGB', .4),
     offColor: 'rgba(0,0,0,.25)',
     rippleColor: new AttrReference('bgPlain'),
   },
   switchStyle: {
-    onColor: new RGBAttrReference('primaryColorRGB', 0.4),
+    onColor: new RGBAttrReference('primaryColorRGB', .4),
     offColor: 'rgba(0,0,0,.25)',
     thumbOnColor: primaryColorRef,
     thumbOffColor: MKColor.Silver,
-    rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
+    rippleColor: new RGBAttrReference('primaryColorRGB', .2),
   },
   radioStyle: {
     borderOnColor: primaryColorRef,
     borderOffColor: primaryColorRef,
     fillColor: primaryColorRef,
-    rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
+    rippleColor: new RGBAttrReference('primaryColorRGB', .2),
   },
   checkboxStyle: {
     borderOnColor: primaryColorRef,
     borderOffColor: 'rgba(0,0,0,.56)',
     fillColor: primaryColorRef,
-    rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
+    rippleColor: new RGBAttrReference('primaryColorRGB', .2),
     inset: 0,
   },
   cardStyle: {
@@ -162,7 +158,7 @@ function isPlainObject(o) {
 function wrapAttrRef(style, attr, attrValue) {
   Object.defineProperty(style, attr, {
     enumerable: true,
-    get() {
+    get: function () {
       return attrValue.value;
     },
   });

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -59,9 +59,9 @@ theme = {
     },
   },
   progressStyle: {
-    backgroundColor: new RGBAttrReference('primaryColorRGB', .3),
+    backgroundColor: new RGBAttrReference('primaryColorRGB', 0.3),
     progressColor: primaryColorRef,
-    bufferColor: new RGBAttrReference('primaryColorRGB', .3),
+    bufferColor: new RGBAttrReference('primaryColorRGB', 0.3),
   },
   spinnerStyle: {
     strokeColor: [
@@ -76,28 +76,28 @@ theme = {
     upperTrackColor: '#cccccc',
   },
   iconToggleStyle: {
-    onColor: new RGBAttrReference('primaryColorRGB', .4),
+    onColor: new RGBAttrReference('primaryColorRGB', 0.4),
     offColor: 'rgba(0,0,0,.25)',
     rippleColor: new AttrReference('bgPlain'),
   },
   switchStyle: {
-    onColor: new RGBAttrReference('primaryColorRGB', .4),
+    onColor: new RGBAttrReference('primaryColorRGB', 0.4),
     offColor: 'rgba(0,0,0,.25)',
     thumbOnColor: primaryColorRef,
     thumbOffColor: MKColor.Silver,
-    rippleColor: new RGBAttrReference('primaryColorRGB', .2),
+    rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
   },
   radioStyle: {
     borderOnColor: primaryColorRef,
     borderOffColor: primaryColorRef,
     fillColor: primaryColorRef,
-    rippleColor: new RGBAttrReference('primaryColorRGB', .2),
+    rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
   },
   checkboxStyle: {
     borderOnColor: primaryColorRef,
     borderOffColor: 'rgba(0,0,0,.56)',
     fillColor: primaryColorRef,
-    rippleColor: new RGBAttrReference('primaryColorRGB', .2),
+    rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
     inset: 0,
   },
   cardStyle: {


### PR DESCRIPTION
Adds scale + color transitions to the floating label animation. See the attached image:

![floating-text-animation](https://cloud.githubusercontent.com/assets/468037/13206678/914fe31c-d8c8-11e5-88c9-b08aa15e450a.gif)

Tested on both iOS and Android.