### PR TITLE
Correcting the tick position

### DIFF
--- a/android/src/main/java/com/github/xinthink/rnmk/widget/TickView.java
+++ b/android/src/main/java/com/github/xinthink/rnmk/widget/TickView.java
@@ -107,7 +107,7 @@ public class TickView extends View implements ReactCompoundView {
         float tickWidth = (float) ((baseSize - this.inset) / Math.sqrt(2));
         float a = (float) (tickWidth / Math.sqrt(2));
         float x0 = left + inset;
-        float y0 = bottom - this.inset - (baseSize - inset);
+        float y0 = bottom - this.inset - (baseSize - inset) - 2; // Leaving 2px gap from bottom
 
         tickPath = new Path();
         tickPath.setFillType(Path.FillType.INVERSE_EVEN_ODD);


### PR DESCRIPTION
Leaving 2px gap from bottom to appear more central. 
(let's remember, as you know [Google leave min. 2 px gap](https://www.google.com/design/spec/style/icons.html#icons-system-icons) between two border line)

![checkbox_before_after](https://cloud.githubusercontent.com/assets/6974198/13661699/9a91e5f0-e69d-11e5-86f7-dc62af49177d.png)
