### PR TITLE
Update Slider.js

### DIFF
--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -99,6 +99,12 @@ class Slider extends Component {
     }
   }
 
+  _emitTouchUp() {
+    if (this.props.onTouchUp) {
+      this.props.onTouchUp(this._value);
+    }
+  }
+  
   _aniUpdateValue(value) {
     if (!this._trackTotalLength) {
       return;
@@ -130,6 +136,7 @@ class Slider extends Component {
         break;
       case 'TOUCH_UP':
         this._confirmUpdateValueByTouch(evt);
+        this._emitTouchUp();
         break;
       case 'TOUCH_CANCEL':
         // should not use the coordination inside a cancelled event
@@ -287,6 +294,9 @@ Slider.propTypes = {
 
   // Callback when value changed
   onChange: PropTypes.func,
+  
+  // Callback when thumb is lifted
+  onTouchUp: PropTypes.func,
 };
 
 // ## <section id='defaults'>Defaults</section>


### PR DESCRIPTION
Added `onTouchUp`, it can be useful if you're not interested in every single update on the slider value.
Currently using it for handling the value of a slider that works as a 'progress bar' for an audio track.