### PR TITLE
Added editable prop to checkbox

### DIFF
--- a/lib/mdl/Checkbox.js
+++ b/lib/mdl/Checkbox.js
@@ -59,6 +59,9 @@ class Checkbox extends Component {
     // How far the ripple can extend outside the Checkbox's border,
     // default is 5
     extraRippleRadius: PropTypes.number,
+
+    // Toggle Editable
+    editable: PropTypes.bool,
   };
 
   // ## <section id='defaults'>Defaults</section>
@@ -72,6 +75,7 @@ class Checkbox extends Component {
       height: 20,
       borderWidth: 2,
       borderRadius: 1,
+      editable: true,
     },
   };
 
@@ -115,7 +119,7 @@ class Checkbox extends Component {
 
   // Touch events handling
   _onTouch = (evt) => {
-    if (evt.type === 'TOUCH_UP') {
+    if (evt.type === 'TOUCH_UP' && this.props.editable) {
       this.confirmToggle();
     }
   };


### PR DESCRIPTION
We are disabling our inputs while the form is being submitted. Having this editable prop simplifies that and I'm sure others will find it useful as well. It also stays inline with how the built-in \<TextInput /\> works.

Let me know if here are any changes or additions you'd like to make.