### PR TITLE
Prevent pan termination request while dragging slider thumbs

### DIFF
--- a/lib/internal/Thumb.js
+++ b/lib/internal/Thumb.js
@@ -58,7 +58,7 @@ class Thumb extends Component {
       onStartShouldSetPanResponderCapture: () => true,
       onMoveShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponderCapture: () => true,
-      onPanResponderTerminationRequest: () => true,
+      onPanResponderTerminationRequest: () => false,
       onShouldBlockNativeResponder: () => true,
 
       onPanResponderGrant: (evt) => { this.props.onGrant(this, evt); },

--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -101,7 +101,7 @@ class Slider extends Component {
           x: this._prevPointerX + gestureState.dx,
         });
       },
-      onPanResponderTerminationRequest: () => true,
+      onPanResponderTerminationRequest: () => false,
       onPanResponderRelease: (evt, gestureState) => {
         this._onPanResponderEnd(gestureState);
       },


### PR DESCRIPTION
### Problem

If the slider components are placed within components that respond to gestures, the parent component's gesture overrides the slider's gesture.

See #114.

### Solution

Deny termination requests from other components while dragging the slider thumbs.

![slider-fix](https://cloud.githubusercontent.com/assets/468037/15100570/bc485794-153a-11e6-9c3e-8a804e673bdd.gif)
