### PR TITLE
Add onStart callback to MKRangeSlider

### DIFF
--- a/lib/internal/Thumb.js
+++ b/lib/internal/Thumb.js
@@ -58,7 +58,7 @@ class Thumb extends Component {
       onStartShouldSetPanResponderCapture: () => true,
       onMoveShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponderCapture: () => true,
-      onPanResponderTerminationRequest: () => true,
+      onPanResponderTerminationRequest: () => false,
       onShouldBlockNativeResponder: () => true,
 
       onPanResponderGrant: (evt) => { this.props.onGrant(this, evt); },

--- a/lib/mdl/RangeSlider.js
+++ b/lib/mdl/RangeSlider.js
@@ -62,6 +62,15 @@ class RangeSlider extends Component {
     }
   };
 
+  // Respond to Grant gestures
+  _beginMove = (ref, evt) => {
+    if (this.props.onStart) {
+      this.props.onStart(ref, evt);
+    }
+
+    this._updateValueByTouch(ref, evt);
+  }
+
   // Respond to both cancelled and finished gestures
   _endMove = (ref, evt) => {
     const ovrRef = this._overriddenThumb ? this._overriddenThumb : ref;
@@ -75,7 +84,7 @@ class RangeSlider extends Component {
     this._emitConfirm();
   };
 
-  // Respond to Grant and Move touch gestures
+  // Respond to Move touch gestures
   _updateValueByTouch = (ref, evt) => {
     const ovrRef = this._overriddenThumb ? this._overriddenThumb : ref;
 
@@ -310,7 +319,7 @@ class RangeSlider extends Component {
           trackMarginH={this._trackMarginH}
           enabledColor={lowerTrackColor}
           disabledColor={upperTrackColor}
-          onGrant = {this._updateValueByTouch}
+          onGrant = {this._beginMove}
           onMove = {this._updateValueByTouch}
           onEnd = {this._endMove}
           style={{
@@ -324,7 +333,7 @@ class RangeSlider extends Component {
           trackMarginH={this._trackMarginH}
           enabledColor={lowerTrackColor}
           disabledColor={upperTrackColor}
-          onGrant = {this._updateValueByTouch}
+          onGrant = {this._beginMove}
           onMove = {this._updateValueByTouch}
           onEnd = {this._endMove}
           style={{
@@ -395,6 +404,9 @@ RangeSlider.propTypes = {
 
   // Color of the upper part of the track
   upperTrackColor: PropTypes.string,
+
+  // Callback when drag gesture begins
+  onStart: PropTypes.func,
 
   // Callback when value changed
   onChange: PropTypes.func,

--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -101,7 +101,7 @@ class Slider extends Component {
           x: this._prevPointerX + gestureState.dx,
         });
       },
-      onPanResponderTerminationRequest: () => true,
+      onPanResponderTerminationRequest: () => false,
       onPanResponderRelease: (evt, gestureState) => {
         this._onPanResponderEnd(gestureState);
       },


### PR DESCRIPTION
### Problem

My app needs to disable scrolling while the sliders are being dragged. I tried using the `onChange` callbacks, but the `onChange` callbacks continue to fire after the `onConfirm` callback is fired.

### Solution

As a workaround, I added an `onStart` callback that fires when dragging begins. This allows me to disable scrolling at the start of the drag event, and then to disable it at the end of the drag event using the `onConfirm` callback.

### Usage

~~~javascript
class MyComponent extends React.Component {
  // disable scrolling while dragging range sliders
  onStart () {
    this.setState({scrollEnabled: false});
  }

  onChange ({min, max}) {
    // handle change
  }

  // re-enable scrolling when range selection is complete
  onConfirm () {
    this.setState({scrollEnabled: true});
  }

  render () {
    <ScrollView
      scrollEnabled={this.state.scrollEnabled} />

      <MKRangeSlider
        onStart={this.props.onStart.bind(this)}
        onConfirm={this.handleConfirm.bind(this)}
        onChange={this.handleChange.bind(this)} />

    </ScrollView>
  }
}
~~~

### Notes

This is built on top of #154.