### PR TITLE
change default underline size

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -302,7 +302,7 @@ Underline.propTypes = {
 Underline.defaultProps = {
   underlineEnabled: true,
   underlineAniDur: FloatingLabel.defaultProps.floatingLabelAniDuration,
-  underlineSize: 1,
+  underlineSize: 2,
 };
 
 


### PR DESCRIPTION
https://getmdl.io/components/index.html also has 2 px underline (when text is being entered into the textfield)