### PR TITLE
Adds allowFontScaling to TextField and it's FloatingLabel

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -144,6 +144,8 @@ class FloatingLabel extends Component {
       <Animated.Text
         ref="label"
         pointerEvents="none"
+        allowFontScaling={this.props.allowFontScaling}
+
         style={[{
           backgroundColor: MKColor.Transparent,
           position: 'absolute',
@@ -181,6 +183,9 @@ FloatingLabel.publicPropTypes = {
   // [Font](MKPropTypes.html#font) of floating label
   // FIXME causing warning: `typeChecker is not a function`
   floatingLabelFont: MKPropTypes.font,
+
+  // Specifies should fonts scale to respect Text Size accessibility setting on iOS.
+  allowFontScaling: PropTypes.bool,
 };
 
 FloatingLabel.propTypes = {
@@ -505,6 +510,8 @@ class Textfield extends Component {
         <FloatingLabel ref="floatingLabel"
           {...props}
           text={this.props.placeholder}
+          allowFontScaling={this.props.allowFontScaling}
+
         />
       );
     }
@@ -536,6 +543,7 @@ class Textfield extends Component {
           onChangeText={this._onTextChange}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
+          allowFontScaling={this.props.allowFontScaling}
         />
         {floatingLabel}
         <Underline ref="underline"  // the underline
@@ -580,6 +588,9 @@ Textfield.propTypes = {
 
   // Style applied to the `TextInput` component, ok to use `StyleSheet`
   textInputStyle: PropTypes.any,
+
+  // Specifies should fonts scale to respect Text Size accessibility setting on iOS.
+  allowFontScaling: PropTypes.bool,
 };
 
 // ## <section id='defaults'>Defaults</section>


### PR DESCRIPTION
Font scaling is when the user changes the global device font size/scale. Standard for Text and TextInput are true (they will scale the font size according to the device setting). This pull request adds an option to disable it on TextFields (automatically does it on it's FloatingLabel too) .