### PR TITLE
[WIP] Disabled controls

### DIFF
--- a/lib/internal/Thumb.js
+++ b/lib/internal/Thumb.js
@@ -49,6 +49,7 @@ class Thumb extends Component {
     this.state = {
       color: LOWEST_VALUE_THUMB_COLOR,
       borderColor: DEFAULT_UPPER_TRACK_COLOR,
+      enabled : true
     };
   }
 
@@ -68,9 +69,7 @@ class Thumb extends Component {
     });
 
     this._onRadiiUpdate(this.props);
-    this.setState({
-      borderColor: this.props.disabledColor,
-    });
+    
   }
 
   componentDidMount() {
@@ -78,7 +77,23 @@ class Thumb extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    if(nextProps.enabled !== this.props.enabled){
+      if(nextProps.enabled === false){
+        console.log('ici');
+        this.setState({
+          borderColor : this.props.disabledColor,        
+          color: this.props.disabledColor,  
+        })
+      }else{
+        console.log('ou là')
+        this.setState({
+          borderColor : this.props.enabledColor,      
+          color: this.props.enabledColor,  
+        })
+      }
+    }
     this._onRadiiUpdate(nextProps);
+
   }
 
   componentWillUnmount() {
@@ -143,10 +158,13 @@ class Thumb extends Component {
 
   // from 'lowest' to 'non-lowest'
   _onExplode() {
-    this.setState({
+    if(this.state.enabled){
+      this.setState({
       borderColor: this.props.enabledColor,
       color: this.props.enabledColor,
     });
+    }
+    
   }
 
   // from 'non-lowest' to 'lowest'
@@ -213,6 +231,8 @@ Thumb.propTypes = {
 
   // Radius of thumb component
   radius: PropTypes.number,
+
+  enabled: PropTypes.bool,
 };
 
 // ## <section id='defaults'>Defaults</section>

--- a/lib/internal/Thumb.js
+++ b/lib/internal/Thumb.js
@@ -79,16 +79,14 @@ class Thumb extends Component {
   componentWillReceiveProps(nextProps) {
     if(nextProps.enabled !== this.props.enabled){
       if(nextProps.enabled === false){
-        console.log('ici');
         this.setState({
           borderColor : this.props.disabledColor,        
           color: this.props.disabledColor,  
         })
       }else{
-        console.log('ou là')
         this.setState({
-          borderColor : this.props.enabledColor,      
-          color: this.props.enabledColor,  
+          borderColor : nextProps.enabledColor,      
+          color: nextProps.enabledColor,  
         })
       }
     }

--- a/lib/mdl/Button.js
+++ b/lib/mdl/Button.js
@@ -55,11 +55,11 @@ class Button extends Component {
   render() {
     const touchableProps = {};
     let ParentContentComponent;
-
+    let mergedStyle = {};
     if (this.props.enabled) {
       Object.assign(touchableProps, utils.extractTouchableProps(this));
-
       ParentContentComponent = Ripple;
+      
     } else {
       ParentContentComponent = View;
     }

--- a/lib/mdl/Button.js
+++ b/lib/mdl/Button.js
@@ -17,6 +17,7 @@ import React, {
 import {
   TouchableWithoutFeedback,
   Text,
+  View
 } from 'react-native';
 
 import MKColor from '../MKColor';

--- a/lib/mdl/Button.js
+++ b/lib/mdl/Button.js
@@ -53,8 +53,14 @@ class Button extends Component {
 
   render() {
     const touchableProps = {};
+    let ParentContentComponent;
+
     if (this.props.enabled) {
       Object.assign(touchableProps, utils.extractTouchableProps(this));
+
+      ParentContentComponent = Ripple;
+    } else {
+      ParentContentComponent = View;
     }
 
     // fix #57 applying `onLayout` to <Ripple>, <TouchableXXX> clones `onLayout` to it's child
@@ -80,7 +86,8 @@ class Button extends Component {
 
     return (
       <TouchableWithoutFeedback {...touchableProps}>
-        <Ripple ref="container"
+        <ParentContentComponent
+          ref="container"
           {...this.props}
           {...maskProps}
           style={[
@@ -89,7 +96,7 @@ class Button extends Component {
           ]}
         >
           {this._renderChildren()}
-        </Ripple>
+        </ParentContentComponent>
       </TouchableWithoutFeedback>
     );
   }

--- a/lib/mdl/Checkbox.js
+++ b/lib/mdl/Checkbox.js
@@ -75,14 +75,14 @@ class Checkbox extends Component {
     editable: PropTypes.bool,
 
     //Toogle editable
-    enable : PropTypes.bool,
+    enabled : PropTypes.bool,
   };
 
   // ## <section id='defaults'>Defaults</section>
   static defaultProps = {
     pointerEvents: 'box-only',
     maskColor: MKColor.Transparent,    
-    enable : true,
+    enabled : true,
     style: {
       justifyContent: 'center',
       alignItems: 'center',
@@ -102,23 +102,23 @@ class Checkbox extends Component {
       width: 0,
       height: 0,
       rippleRadii: 0,
-      enable : true
+      enabled : true
     };
   }
 
   componentWillMount() {
     //!@depreacated
-    let enable = this.props.enable
+    let enabled = this.props.enabled
     if(this.props.editable !== undefined){
-      enable = this.props.editable
-      console.warn('Editable props of MKCheckbox is depreacated. Use editable instead')
+      enabled = this.props.editable
+      console.warn('Editable props of MKCheckbox is depreacated. Use enabled instead')
     }
-    this._initView(this.props.checked, enable);
+    this._initView(this.props.checked, enabled);
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.checked !== this.props.checked) {
-      this._initView(nextProps.checked);
+    if (nextProps.checked !== this.props.checked || nextProps.enabled !== this.props.enabled ) {
+      this._initView(nextProps.checked, nextProps.enabled);
     }
   }
 
@@ -140,20 +140,20 @@ class Checkbox extends Component {
 
   // Touch events handling
   _onTouch = (evt) => {
-    if (evt.type === 'TOUCH_UP' && this.state.enable ){
+    if (evt.type === 'TOUCH_UP' && this.state.enabled ){
       this.confirmToggle();
     }
   };
   // property initializers end
 
-  _initView(checked, enable) {
-    this.setState({ 'checked' : checked , 'enable' : enable });
+  _initView(checked, enabled) {
+    this.setState({ 'checked' : checked , 'enabled' : enabled });
     this._aniToggle(checked);
   }
 
   // When a toggle action (from the given state) is confirmed.
   confirmToggle() {
-    if(this.state.enable === false){
+    if(this.state.enabled === false){
       return;
     }
     const prevState = this.state.checked;
@@ -177,31 +177,23 @@ class Checkbox extends Component {
   }
 
   render() {
-    const defaultStyle = this.theme.checkboxStyle;
-    let mergedStyle;
-    let borderColor;
-    if(this.state.enable === true){
-      mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, [
-      'borderOnColor' ,
-      'borderOffColor',
-      'fillColor',
-      'rippleColor',
-      'inset',
-      ]));
-      borderColor = this.state.checked ? mergedStyle.borderOnColor : mergedStyle.borderOffColor;
-    }else{
-      mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, [
-      'disabledDorderOnColor' ,
-      'disableBorderOffColor',
-      'disabledFillColor',
-      'rippleColor',
-      ]));
-      mergedStyle.fillColor = mergedStyle.disabledFillColor
-      borderColor = this.state.checked ? mergedStyle.disabledBorderOnColor : mergedStyle.disabledBorderOffColor;
-    }
+
+    const defaultStyle = this.state.enabled ? this.theme.checkboxStyle.enabled : this.theme.checkboxStyle.disabled;
+    
+    let properties = utils.getPropertiesByContext([
+                'borderOnColor' ,
+                'borderOffColor',
+                'fillColor',
+                'rippleColor',
+                'inset',
+                ], this.state.enabled ? 'enabled' : 'disabled');
+    const  mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, properties));
+   
+    const borderColor = this.state.checked ? mergedStyle.borderOnColor : mergedStyle.borderOffColor;
+
     
     let ParentContentComponent;
-    if(this.state.enable){
+    if(this.state.enabled){
       ParentContentComponent = Ripple
     }else{
       ParentContentComponent = View

--- a/lib/mdl/Checkbox.js
+++ b/lib/mdl/Checkbox.js
@@ -179,7 +179,7 @@ class Checkbox extends Component {
   render() {
 
     const defaultStyle = this.state.enabled ? this.theme.checkboxStyle.enabled : this.theme.checkboxStyle.disabled;
-    
+    let styledProperties;
     let properties = utils.getPropertiesByContext([
                 'borderOnColor' ,
                 'borderOffColor',
@@ -187,8 +187,20 @@ class Checkbox extends Component {
                 'rippleColor',
                 'inset',
                 ], this.state.enabled ? 'enabled' : 'disabled');
+      
+    if(!this.state.enabled){
+      let test = utils.extractProps(this, properties);
+      console.log(test);
+      properties.map((p) => {
+        console.log('test ', test);
+        console.log('styledProperties', styledProperties)
+        styledProperties[p] =  '' 
+      })
+      console.log(styledProperties);
+    }
+    
     const  mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, properties));
-   
+   console.log(mergedStyle);
     const borderColor = this.state.checked ? mergedStyle.borderOnColor : mergedStyle.borderOffColor;
 
     

--- a/lib/mdl/Checkbox.js
+++ b/lib/mdl/Checkbox.js
@@ -178,30 +178,31 @@ class Checkbox extends Component {
 
   render() {
 
-    const defaultStyle = this.state.enabled ? this.theme.checkboxStyle.enabled : this.theme.checkboxStyle.disabled;
+    const defaultStyle = this.theme.checkboxStyle;
     let styledProperties;
-    let properties = utils.getPropertiesByContext([
-                'borderOnColor' ,
-                'borderOffColor',
-                'fillColor',
-                'rippleColor',
-                'inset',
-                ], this.state.enabled ? 'enabled' : 'disabled');
+    let properties = [
+      'borderOnColor' ,
+      'borderOffColor',
+      'fillColor',
+      'rippleColor',
+      'inset',
+    ]
       
     if(!this.state.enabled){
-      let test = utils.extractProps(this, properties);
-      console.log(test);
-      properties.map((p) => {
-        console.log('test ', test);
-        console.log('styledProperties', styledProperties)
-        styledProperties[p] =  '' 
-      })
-      console.log(styledProperties);
+      properties = [
+        'disabledBorderOnColor' ,
+        'disabledBorderOffColor',
+        'disabledFillColor',
+        'disabledRippleColor',
+        'disabledInset',
+      ]
     }
-    
-    const  mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, properties));
+    console.log('prop', properties)
+    const mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, properties));
    console.log(mergedStyle);
-    const borderColor = this.state.checked ? mergedStyle.borderOnColor : mergedStyle.borderOffColor;
+    const borderColor = this.state.checked ? 
+            (this.state.enabled ? mergedStyle.borderOnColor : mergedStyle.disabledBorderOnColor) : 
+            (this.state.enabled ? mergedStyle.borderOffColor : mergedStyle.disabledBorderOffColor);
 
     
     let ParentContentComponent;
@@ -216,7 +217,7 @@ class Checkbox extends Component {
           {...this.props}
           maskBorderRadiusInPercent={50}
           rippleLocation="center"
-          rippleColor={mergedStyle.rippleColor}
+          rippleColor={ this.state.enabled ? mergedStyle.rippleColor : mergedStyle.disabledRippleColor}
           onTouch={this._onTouch}
           style={{
             justifyContent: 'center',
@@ -236,8 +237,8 @@ class Checkbox extends Component {
             onLayout={this._onLayout}
           >
             <Tick.animated ref="tick"
-              inset={mergedStyle.inset}
-              fillColor={mergedStyle.fillColor}
+              inset={this.state.enabled ? mergedStyle.inset : mergedStyle.disabledInset}
+              fillColor={this.state.enabled ? mergedStyle.fillColor : mergedStyle.disabledFillColor}
               style={{
                 flex: 1,
                 opacity: this._animatedTickAlpha,

--- a/lib/mdl/Checkbox.js
+++ b/lib/mdl/Checkbox.js
@@ -56,7 +56,7 @@ class Checkbox extends Component {
     disabledBorderOnColor: PropTypes.string,
 
     // Color of the border (outer circle), when unchecked and disabled
-    disabledBborderOffColor: PropTypes.string,
+    disabledBorderOffColor: PropTypes.string,
 
     // Color of the inner circle, when checked and disabled
     disabledFillColor: PropTypes.string,
@@ -179,7 +179,6 @@ class Checkbox extends Component {
   render() {
 
     const defaultStyle = this.theme.checkboxStyle;
-    let styledProperties;
     let properties = [
       'borderOnColor' ,
       'borderOffColor',

--- a/lib/mdl/Checkbox.js
+++ b/lib/mdl/Checkbox.js
@@ -197,9 +197,7 @@ class Checkbox extends Component {
         'disabledInset',
       ]
     }
-    console.log('prop', properties)
     const mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, properties));
-   console.log(mergedStyle);
     const borderColor = this.state.checked ? 
             (this.state.enabled ? mergedStyle.borderOnColor : mergedStyle.disabledBorderOnColor) : 
             (this.state.enabled ? mergedStyle.borderOffColor : mergedStyle.disabledBorderOffColor);

--- a/lib/mdl/Checkbox.js
+++ b/lib/mdl/Checkbox.js
@@ -52,6 +52,15 @@ class Checkbox extends Component {
     // Color of the inner circle, when checked
     fillColor: PropTypes.string,
 
+    // Color of the border (outer circle), when checked and disabled
+    disabledBorderOnColor: PropTypes.string,
+
+    // Color of the border (outer circle), when unchecked and disabled
+    disabledBborderOffColor: PropTypes.string,
+
+    // Color of the inner circle, when checked and disabled
+    disabledFillColor: PropTypes.string,
+
     // Toggle status
     checked: PropTypes.bool,
 
@@ -64,13 +73,16 @@ class Checkbox extends Component {
 
     // Toggle Editable
     editable: PropTypes.bool,
+
+    //Toogle editable
+    enable : PropTypes.bool,
   };
 
   // ## <section id='defaults'>Defaults</section>
   static defaultProps = {
     pointerEvents: 'box-only',
-    maskColor: MKColor.Transparent,
-    editable: true,
+    maskColor: MKColor.Transparent,    
+    enable : true,
     style: {
       justifyContent: 'center',
       alignItems: 'center',
@@ -90,11 +102,18 @@ class Checkbox extends Component {
       width: 0,
       height: 0,
       rippleRadii: 0,
+      enable : true
     };
   }
 
   componentWillMount() {
-    this._initView(this.props.checked);
+    //!@depreacated
+    let enable = this.props.enable
+    if(this.props.editable !== undefined){
+      enable = this.props.editable
+      console.warn('Editable props of MKCheckbox is depreacated. Use editable instead')
+    }
+    this._initView(this.props.checked, enable);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -121,19 +140,22 @@ class Checkbox extends Component {
 
   // Touch events handling
   _onTouch = (evt) => {
-    if (evt.type === 'TOUCH_UP' && this.props.editable) {
+    if (evt.type === 'TOUCH_UP' && this.state.enable ){
       this.confirmToggle();
     }
   };
   // property initializers end
 
-  _initView(checked) {
-    this.setState({ checked });
+  _initView(checked, enable) {
+    this.setState({ 'checked' : checked , 'enable' : enable });
     this._aniToggle(checked);
   }
 
   // When a toggle action (from the given state) is confirmed.
   confirmToggle() {
+    if(this.state.enable === false){
+      return;
+    }
     const prevState = this.state.checked;
     const newState = !prevState;
 
@@ -156,18 +178,37 @@ class Checkbox extends Component {
 
   render() {
     const defaultStyle = this.theme.checkboxStyle;
-    const mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, [
-      'borderOnColor',
+    let mergedStyle;
+    let borderColor;
+    if(this.state.enable === true){
+      mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, [
+      'borderOnColor' ,
       'borderOffColor',
       'fillColor',
       'rippleColor',
       'inset',
-    ]));
-    const borderColor = this.state.checked ? mergedStyle.borderOnColor : mergedStyle.borderOffColor;
-
+      ]));
+      borderColor = this.state.checked ? mergedStyle.borderOnColor : mergedStyle.borderOffColor;
+    }else{
+      mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, [
+      'disabledDorderOnColor' ,
+      'disableBorderOffColor',
+      'disabledFillColor',
+      'rippleColor',
+      ]));
+      mergedStyle.fillColor = mergedStyle.disabledFillColor
+      borderColor = this.state.checked ? mergedStyle.disabledBorderOnColor : mergedStyle.disabledBorderOffColor;
+    }
+    
+    let ParentContentComponent;
+    if(this.state.enable){
+      ParentContentComponent = Ripple
+    }else{
+      ParentContentComponent = View
+    }
     return (
       <TouchableWithoutFeedback {...utils.extractTouchableProps(this)} >
-        <Ripple
+        <ParentContentComponent
           {...this.props}
           maskBorderRadiusInPercent={50}
           rippleLocation="center"
@@ -199,7 +240,7 @@ class Checkbox extends Component {
               }}
             />
           </View>
-        </Ripple>
+        </ParentContentComponent>
       </TouchableWithoutFeedback>
     );
   }

--- a/lib/mdl/IconToggle.js
+++ b/lib/mdl/IconToggle.js
@@ -16,6 +16,7 @@ import React, {
 
 import {
   TouchableWithoutFeedback,
+  View
 } from 'react-native';
 
 import MKColor from '../MKColor';
@@ -47,6 +48,9 @@ class IconToggle extends Component {
     onCheckedChange: PropTypes.func,
 
     children: PropTypes.node,
+
+    //control is enabled?
+    enabled : PropTypes.bool
   };
 
   // ## <section id='defaults'>Defaults</section>
@@ -111,10 +115,12 @@ class IconToggle extends Component {
     const mergedStyle = Object.assign({}, this.theme.iconToggleStyle, utils.compact({
       rippleColor: this.props.rippleColor,
     }));
-
+    const ParentContentComponent = this.props.enabled ? Ripple : View; 
+      
+    
     return (
       <TouchableWithoutFeedback {...utils.extractTouchableProps(this)}>
-        <Ripple
+        <ParentContentComponent
           {...this.props}
           rippleColor={mergedStyle.rippleColor}
           style={[IconToggle.defaultProps.style]}
@@ -123,7 +129,7 @@ class IconToggle extends Component {
           onTouch={this._onTouch}
         >
           {this._renderChildren()}
-        </Ripple>
+        </ParentContentComponent>
       </TouchableWithoutFeedback>
     );
   }

--- a/lib/mdl/IconToggle.js
+++ b/lib/mdl/IconToggle.js
@@ -70,7 +70,7 @@ class IconToggle extends Component {
   constructor(props) {
     super(props);
     this.theme = getTheme();
-    this.state = { checked: false };
+    this.state = { checked: false , enabled : true};
   }
 
   componentWillMount() {
@@ -112,8 +112,9 @@ class IconToggle extends Component {
   }
 
   render() {
-    const mergedStyle = Object.assign({}, this.theme.iconToggleStyle, utils.compact({
+    const mergedStyle = Object.assign({}, this.theme.iconToggleStyle.props, utils.compact({
       rippleColor: this.props.rippleColor,
+      disabledRippleColor : this.props.disabledRippleColor
     }));
     const ParentContentComponent = this.props.enabled ? Ripple : View; 
       
@@ -122,8 +123,8 @@ class IconToggle extends Component {
       <TouchableWithoutFeedback {...utils.extractTouchableProps(this)}>
         <ParentContentComponent
           {...this.props}
-          rippleColor={mergedStyle.rippleColor}
-          style={[IconToggle.defaultProps.style]}
+          rippleColor={this.state.enabled ? mergedStyle.rippleColor : mergedStyle.disabledRippleColor}
+          style={Object.assign({}, this.theme.iconToggleStyle.style, this.props.style)}
           maskBorderRadiusInPercent={50}
           rippleLocation="center"
           onTouch={this._onTouch}

--- a/lib/mdl/RadioButton.js
+++ b/lib/mdl/RadioButton.js
@@ -47,6 +47,15 @@ class RadioButton extends Component {
     // Color of the inner circle, when checked
     fillColor: PropTypes.string,
 
+    // Color of the border (outer circle), when checked and disabled
+    disabledBorderOnColor: PropTypes.string,
+
+    // Color of the border (outer circle), when unchecked and disabled
+    disabledBorderOffColor: PropTypes.string,
+
+    // Color of the inner circle, when checked and disabled
+    disabledFillColor: PropTypes.string,
+
     // Toggle status
     checked: PropTypes.bool,
 
@@ -59,12 +68,15 @@ class RadioButton extends Component {
     // How far the ripple can extend outside the RadioButton's border,
     // default is 16
     extraRippleRadius: PropTypes.number,
+    //Toogle editable
+    enabled : PropTypes.bool,
   };
 
   // ## <section id='defaults'>Defaults</section>
   static defaultProps = {
     pointerEvents: 'box-only',
     maskColor: MKColor.Transparent,
+    enabled : true,
     style: {
       justifyContent: 'center',
       alignItems: 'center',
@@ -85,23 +97,24 @@ class RadioButton extends Component {
       checked: false,
       width: 0,
       height: 0,
+      enabled : true
     };
   }
 
   componentWillMount() {
     this.group = this.props.group;
-    this._initView(this.props.checked);
+    this._initView(this.props.checked, this.props.enabled);
   }
 
   componentWillReceiveProps(nextProps) {
     this.group = nextProps.group;
-    if (nextProps.checked !== this.props.checked) {
-      this._initView(nextProps.checked);
+    if (nextProps.checked !== this.props.checked || nextProps.enabled !== this.props.enabled ) {
+      this._initView(nextProps.checked, nextProps.enabled);
     }
   }
 
-  _initView(checked) {
-    this.setState({ checked });
+  _initView(checked, enabled) {
+    this.setState({ checked, enabled });
     this._aniChecked(checked);
   }
 
@@ -120,7 +133,7 @@ class RadioButton extends Component {
 
   // Touch events handling
   _onTouch = (evt) => {
-    if (evt.type === 'TOUCH_UP') {
+    if (evt.type === 'TOUCH_UP' && this.state.enabled) {
       if (!this.state.checked) {
         this.confirmToggle();
       }
@@ -130,6 +143,9 @@ class RadioButton extends Component {
 
   // When a toggle action (from the given state) is confirmed.
   confirmToggle() {
+    if(this.state.enabled === false){
+      return;
+    }
     const prevState = this.state.checked;
     const newState = !prevState;
 
@@ -175,21 +191,38 @@ class RadioButton extends Component {
 
   render() {
     const defaultStyle = this.theme.radioStyle;
-    const mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, [
-      'borderOnColor',
+    let properties = [
+      'borderOnColor' ,
       'borderOffColor',
       'fillColor',
       'rippleColor',
-    ]));
-    const borderColor = this.state.checked ? mergedStyle.borderOnColor : mergedStyle.borderOffColor;
-
+    ]
+      
+    if(!this.state.enabled){
+      properties = [
+        'disabledBorderOnColor' ,
+        'disabledBorderOffColor',
+        'disabledFillColor',
+        'disabledRippleColor',
+      ]
+    }
+    const mergedStyle = Object.assign({}, defaultStyle, utils.extractProps(this, properties));
+    const borderColor = this.state.checked ? 
+            (this.state.enabled ? mergedStyle.borderOnColor : mergedStyle.disabledBorderOnColor) : 
+            (this.state.enabled ? mergedStyle.borderOffColor : mergedStyle.disabledBorderOffColor);
+    let ParentContentComponent;
+    if(this.state.enabled){
+      ParentContentComponent = Ripple
+    }else{
+      ParentContentComponent = View
+    }        
     return (
       <TouchableWithoutFeedback {...utils.extractTouchableProps(this)} >
-        <Ripple
+        <ParentContentComponent
           {...this.props}
           maskBorderRadiusInPercent={50}
           rippleLocation="center"
-          rippleColor={mergedStyle.rippleColor}
+          rippleColor={ this.state.enabled ? mergedStyle.rippleColor : mergedStyle.disabledRippleColor}
           onTouch={this._onTouch}
           style={{
             justifyContent: 'center',
@@ -209,14 +242,14 @@ class RadioButton extends Component {
             <Animated.View
               ref="innerCircle"
               style={{
-                backgroundColor: mergedStyle.fillColor,
+                backgroundColor: (this.state.enabled) ? mergedStyle.fillColor : mergedStyle.disabledFillColor,
                 width: this._animatedSize,
                 height: this._animatedSize,
                 borderRadius: this._animatedRadius,
               }}
             />
           </View>
-        </Ripple>
+        </ParentContentComponent>
       </TouchableWithoutFeedback>
     );
   }

--- a/lib/mdl/RangeSlider.js
+++ b/lib/mdl/RangeSlider.js
@@ -44,6 +44,9 @@ class RangeSlider extends Component {
     this._trackTotalLength = 0;
     this._lowerTrackLength = new Animated.Value(this._range.max - this._range.min);
     this._lowerTrackMin = new Animated.Value(this._range.min);
+    this.state = {
+      enabled : this.props.enabled
+    }
   }
 
   componentWillMount() {
@@ -51,6 +54,9 @@ class RangeSlider extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    if(this.props.enabled !== nextProps.enabled){
+      this.setState({enabled : nextProps.enabled})
+    }
     this._onThumbRadiiUpdate(nextProps);
   }
 
@@ -65,6 +71,9 @@ class RangeSlider extends Component {
 
   // Respond to Grant gestures
   _beginMove = (ref, evt) => {
+    if(!this.state.enabled){
+      return
+    }
     if (this.props.onStart) {
       this.props.onStart(ref, evt);
     }
@@ -87,6 +96,9 @@ class RangeSlider extends Component {
 
   // Respond to Move touch gestures
   _updateValueByTouch = (ref, evt) => {
+    if(!this.state.enabled){
+      return
+    }
     const ovrRef = this._overriddenThumb ? this._overriddenThumb : ref;
 
     const dx = evt.nativeEvent.pageX;
@@ -282,8 +294,8 @@ class RangeSlider extends Component {
     };
 
     const sliderStyle = this.theme.sliderStyle;
-    const lowerTrackColor = this.props.lowerTrackColor || sliderStyle.lowerTrackColor;
-    const upperTrackColor = this.props.upperTrackColor || sliderStyle.upperTrackColor;
+    const lowerTrackColor = (this.state.enabled ? (this.props.lowerTrackColor || sliderStyle.lowerTrackColor) : (this.props.disabledLowerTrackColor || sliderStyle.disabledLowerTrackColor));
+    const upperTrackColor = (this.state.enabled ? (this.props.upperTrackColor || sliderStyle.upperTrackColor) : (this.props.disabledUpperTrackColor || sliderStyle.disabledUpperTrackColor));
 
     return (
       <View ref="container"
@@ -320,6 +332,7 @@ class RangeSlider extends Component {
           trackMarginH={this._trackMarginH}
           enabledColor={lowerTrackColor}
           disabledColor={upperTrackColor}
+          enabled={this.state.enabled}
           onGrant = {this._beginMove}
           onMove = {this._updateValueByTouch}
           onEnd = {this._endMove}
@@ -334,6 +347,7 @@ class RangeSlider extends Component {
           trackMarginH={this._trackMarginH}
           enabledColor={lowerTrackColor}
           disabledColor={upperTrackColor}
+          enabled={this.state.enabled}
           onGrant = {this._beginMove}
           onMove = {this._updateValueByTouch}
           onEnd = {this._endMove}
@@ -417,6 +431,15 @@ RangeSlider.propTypes = {
 
   // Step value of the RangeSlider, must be a divisor of max
   step: PropTypes.number,
+
+  //control is enabled?
+  enabled : PropTypes.bool,
+
+  // Color of the lower part of the track when disabled, it's also the color of the thumb
+  disabledLowerTrackColor: PropTypes.string,
+
+  // Color of the upper part of the track when disabled
+  disabledUpperTrackColor: PropTypes.string,
 };
 
 // ## <section id='defaults'>Defaults</section>
@@ -426,6 +449,7 @@ RangeSlider.defaultProps = {
   min: 0,
   max: 100,
   step: 1,
+  enabled : true
 };
 
 

--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -62,6 +62,12 @@ class Slider extends Component {
     // Color of the upper part of the track
     upperTrackColor: PropTypes.string,
 
+     // Color of the lower part of the track when disabled, it's also the color of the thumb
+    disabledLowerTrackColor: PropTypes.string,
+
+    // Color of the upper part of the track when disabled
+    disabledUpperTrackColor: PropTypes.string,
+
     // Callback when value changed
     onChange: PropTypes.func,
 
@@ -120,9 +126,10 @@ class Slider extends Component {
       enabled : this.props.enabled
     }
   }
-_handleStartShouldSetPanResponder(e,gst){
-  return this.state.enabled;
-}
+  //If slider is enabled, then we setPanResponder
+  _handleStartShouldSetPanResponder(){
+    return this.state.enabled;
+  }
   componentWillMount() {
     this._onThumbRadiiUpdate(this.props);
     this._internalSetValue(this.props.value, false);
@@ -135,9 +142,7 @@ _handleStartShouldSetPanResponder(e,gst){
       })
     }
     this._onThumbRadiiUpdate(nextProps);
-    this._internalSetValue(nextProps.value, false);
-      
-    
+    this._internalSetValue(nextProps.value, false);   
   }
 
   // region Property initializers
@@ -274,7 +279,6 @@ _handleStartShouldSetPanResponder(e,gst){
     const lowerTrackColor = (this.state.enabled ? (this.props.lowerTrackColor || sliderStyle.lowerTrackColor) : (this.props.disabledLowerTrackColor || sliderStyle.disabledLowerTrackColor));
     const upperTrackColor = (this.state.enabled ? (this.props.upperTrackColor || sliderStyle.upperTrackColor) : (this.props.disabledUpperTrackColor || sliderStyle.disabledUpperTrackColor));
     const pandHanlders =  (this.state.enabled ? {...this._panResponder.panHandlers} : null);
-    console.log('pandHanlders', pandHanlders);
     
     return (
        <View ref="container" 

--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -67,6 +67,9 @@ class Slider extends Component {
 
     // Callback when the value is confirmed
     onConfirm: PropTypes.func,
+
+    //control is enabled?
+    enabled : PropTypes.bool
   };
 
   // ## <section id='defaults'>Defaults</section>
@@ -75,6 +78,7 @@ class Slider extends Component {
     trackSize: 2,
     min: 0,
     max: 100,
+    enabled : true
   };
   // endregion
 
@@ -86,10 +90,10 @@ class Slider extends Component {
     this._prevPointerX = 0;
     this._animatedTrackLength = new Animated.Value(0);
     this._panResponder = PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onStartShouldSetPanResponderCapture: () => true,
-      onMoveShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponderCapture: () => true,
+      onStartShouldSetPanResponder: () => false,
+      onStartShouldSetPanResponderCapture: () => this._handleStartShouldSetPanResponder(),
+      onMoveShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponderCapture: () => this._handleStartShouldSetPanResponder(),
       onPanResponderGrant: (evt) => {
         this._prevPointerX = evt.nativeEvent.locationX;
         this._onTouchEvent({
@@ -112,16 +116,28 @@ class Slider extends Component {
       },
       onShouldBlockNativeResponder: () => true,
     });
+    this.state = {
+      enabled : this.props.enabled
+    }
   }
-
+_handleStartShouldSetPanResponder(e,gst){
+  return this.state.enabled;
+}
   componentWillMount() {
     this._onThumbRadiiUpdate(this.props);
     this._internalSetValue(this.props.value, false);
   }
 
   componentWillReceiveProps(nextProps) {
+    if(nextProps.enabled !== this.props.enabled){
+      this.setState({
+        enabled : nextProps.enabled
+      })
+    }
     this._onThumbRadiiUpdate(nextProps);
     this._internalSetValue(nextProps.value, false);
+      
+    
   }
 
   // region Property initializers
@@ -255,22 +271,16 @@ class Slider extends Component {
     };
 
     const sliderStyle = this.theme.sliderStyle;
-    const lowerTrackColor = this.props.lowerTrackColor || sliderStyle.lowerTrackColor;
-    const upperTrackColor = this.props.upperTrackColor || sliderStyle.upperTrackColor;
-
+    const lowerTrackColor = (this.state.enabled ? (this.props.lowerTrackColor || sliderStyle.lowerTrackColor) : (this.props.disabledLowerTrackColor || sliderStyle.disabledLowerTrackColor));
+    const upperTrackColor = (this.state.enabled ? (this.props.upperTrackColor || sliderStyle.upperTrackColor) : (this.props.disabledUpperTrackColor || sliderStyle.disabledUpperTrackColor));
+    const pandHanlders =  (this.state.enabled ? {...this._panResponder.panHandlers} : null);
+    console.log('pandHanlders', pandHanlders);
+    
     return (
-      <View ref="container"
-        style={[this.props.style, {
-          padding: 0,
-          paddingTop: 0,
-          paddingBottom: 0,
-          paddingLeft: 0,
-          paddingRight: 0,
-        }]}
-        pointerEvents="box-only"
-        {...this._panResponder.panHandlers}
-      >
-        <View ref="track"
+       <View ref="container" 
+      style={[this.props.style, { padding: 0,  paddingTop: 0, paddingBottom: 0,paddingLeft: 0,paddingRight: 0,}]} 
+      pointerEvents="box-only" {...pandHanlders} >
+      <View ref="track"
           style={{
             height: this.props.trackSize,
             backgroundColor: upperTrackColor,
@@ -295,11 +305,13 @@ class Slider extends Component {
           trackMarginH={this._trackMarginH}
           enabledColor={lowerTrackColor}
           disabledColor={upperTrackColor}
+          enabled={this.state.enabled}
           style={{
             top: this._thumbRadiiWithBorder * (THUMB_SCALE_RATIO - 1) + TRACK_EXTRA_MARGIN_V,
-          }}
-        />
-      </View>
+          }} />
+          </View>
+        
+      
     );
   }
 }

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -70,8 +70,8 @@ Object.assign(theme, {
   sliderStyle: {
     lowerTrackColor: primaryColorRef,
     upperTrackColor: '#cccccc',
-    disabledLowerTrackColor : 'rgba(0, 0, 0, 0.12)',
-    disabledUpperTrackColor : 'rgba(0, 0, 0, 0.12)',
+    disabledLowerTrackColor : '#cccccc',
+    disabledUpperTrackColor : '#cccccc',
   },
   iconToggleStyle: {
     props : {

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -98,9 +98,9 @@ Object.assign(theme, {
       inset: 0,
     }, 
     disabled : {
-      borderOnColor : 'red',
-      borderOffColor : 'red',
-      fillColor : 'red',
+      borderOnColor : 'rgba(0, 0, 0, 0.12)',
+      borderOffColor : 'rgba(0, 0, 0, 0.12)',
+      fillColor : 'rgba(0, 0, 0, 0.12)',
       inset: 0,
     },
   },

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -90,14 +90,19 @@ Object.assign(theme, {
     rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
   },
   checkboxStyle: {
-    borderOnColor: primaryColorRef,
-    borderOffColor: 'rgba(0, 0, 0, 0.56)',
-    fillColor: primaryColorRef,
-    rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
-    inset: 0,
-    disabledBorderOnColor : 'red',
-    disabledBorderOffColor : 'red',
-    disabledFillColor : 'red'
+    enabled  : {
+      borderOnColor: primaryColorRef,
+      borderOffColor: 'rgba(0, 0, 0, 0.56)',
+      fillColor: primaryColorRef,
+      rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
+      inset: 0,
+    }, 
+    disabled : {
+      borderOnColor : 'red',
+      borderOffColor : 'red',
+      fillColor : 'red',
+      inset: 0,
+    },
   },
   cardStyle: {
     flex: 1,

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -95,6 +95,9 @@ Object.assign(theme, {
     fillColor: primaryColorRef,
     rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
     inset: 0,
+    disabledBorderOnColor : 'red',
+    disabledBorderOffColor : 'red',
+    disabledFillColor : 'red'
   },
   cardStyle: {
     flex: 1,

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -70,11 +70,29 @@ Object.assign(theme, {
   sliderStyle: {
     lowerTrackColor: primaryColorRef,
     upperTrackColor: '#cccccc',
+    disabledLowerTrackColor : 'rgba(0, 0, 0, 0.12)',
+    disabledUpperTrackColor : 'rgba(0, 0, 0, 0.12)',
   },
   iconToggleStyle: {
-    onColor: new RGBAttrReference('primaryColorRGB', 0.4),
-    offColor: 'rgba(0, 0, 0, 0.25)',
-    rippleColor: new AttrReference('bgPlain'),
+    props : {
+      onColor: new RGBAttrReference('primaryColorRGB', 0.4),
+      offColor: 'rgba(0, 0, 0, 0.25)',
+      rippleColor: new AttrReference('bgPlain'),
+      maskColor: MKColor.Transparent,
+      disabledOnColor : 'red',
+      disabledOffColor : 'red',
+      disabledRippleColor : 'red',
+      disabledMaskColor : 'red'
+
+    },
+    style : {
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderColor: 'rgba(0,0,0,.54)',
+      width: 56,
+      height: 56,
+    }    
+      
   },
   switchStyle: {
     onColor: new RGBAttrReference('primaryColorRGB', 0.4),
@@ -90,19 +108,17 @@ Object.assign(theme, {
     rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
   },
   checkboxStyle: {
-    enabled  : {
       borderOnColor: primaryColorRef,
       borderOffColor: 'rgba(0, 0, 0, 0.56)',
       fillColor: primaryColorRef,
       rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
       inset: 0,
-    }, 
-    disabled : {
-      borderOnColor : 'rgba(0, 0, 0, 0.12)',
-      borderOffColor : 'rgba(0, 0, 0, 0.12)',
-      fillColor : 'rgba(0, 0, 0, 0.12)',
-      inset: 0,
-    },
+     
+      disabledBorderOnColor : 'rgba(0, 0, 0, 0.12)',
+      disabledBorderOffColor : 'rgba(0, 0, 0, 0.12)',
+      disabledFillColor : 'rgba(0, 0, 0, 0.12)',
+      disabledInset: 0,
+    
   },
   cardStyle: {
     flex: 1,

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -106,6 +106,9 @@ Object.assign(theme, {
     borderOffColor: primaryColorRef,
     fillColor: primaryColorRef,
     rippleColor: new RGBAttrReference('primaryColorRGB', 0.2),
+    disabledBorderOnColor : 'rgba(0, 0, 0, 0.12)',
+    disabledBorderOffColor : 'rgba(0, 0, 0, 0.12)',
+    disabledFillColor : 'rgba(0, 0, 0, 0.12)',
   },
   checkboxStyle: {
       borderOnColor: primaryColorRef,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,30 +66,7 @@ function extractTouchableProps(view) {
   });
 }
 
-//Extract right properties depending on the context. 
-//Context is : enabled or disabled 
-function getPropertiesByContext(properties, context){
-  if(context !== 'enabled' && context !== 'disabled'){
-    console.error('The given context is not right!');
-    return; 
-  }
-  //By default 
-  if(context === 'enabled'){
-    return properties;
-  }
-  if(context === 'disabled'){
-    let disabledProperties = [];
-    properties.map( (prop) => {
-      prop = 'disabled' + __capitalizeFirstLetter(prop);
-      disabledProperties.push(prop);
-    })
-    return disabledProperties;
-  }
-}
 
-function __capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-}
 // ## Public interface
 export {
   compact,
@@ -100,6 +77,5 @@ export {
   extractProps,
   extractPropsBy,
   extractTouchableProps,
-  getPropertiesByContext,
   processColor as parseColor,  // parse stringified color as int
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,7 +66,30 @@ function extractTouchableProps(view) {
   });
 }
 
+//Extract right properties depending on the context. 
+//Context is : enabled or disabled 
+function getPropertiesByContext(properties, context){
+  if(context !== 'enabled' && context !== 'disabled'){
+    console.error('The given context is not right!');
+    return; 
+  }
+  //By default 
+  if(context === 'enabled'){
+    return properties;
+  }
+  if(context === 'disabled'){
+    let disabledProperties = [];
+    properties.map( (prop) => {
+      prop = 'disabled' + __capitalizeFirstLetter(prop);
+      disabledProperties.push(prop);
+    })
+    return disabledProperties;
+  }
+}
 
+function __capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
 // ## Public interface
 export {
   compact,
@@ -77,5 +100,6 @@ export {
   extractProps,
   extractPropsBy,
   extractTouchableProps,
+  getPropertiesByContext,
   processColor as parseColor,  // parse stringified color as int
 };


### PR DESCRIPTION
This PR is a Work In Progress (only few components and only tested on iOS) 

Currently supported controls : 

- [x] Button
- [x] Checkbox
- [x] Slider
- [x] RangeSlider
- [x] RadioButton
- [ ] Switch

You can add `enable={true|false}` to each controls. If the component has some props to stylish it, you can also stylish the disabled state. 


```jsx
// Color of the border (outer circle), when checked
    borderOnColor: PropTypes.string,

    // Color of the border (outer circle), when unchecked
    borderOffColor: PropTypes.string,

    // Color of the inner circle, when checked
    fillColor: PropTypes.string,

    // Color of the border (outer circle), when checked and disabled
    disabledBorderOnColor: PropTypes.string,

    // Color of the border (outer circle), when unchecked and disabled
    disabledBorderOffColor: PropTypes.string,

    // Color of the inner circle, when checked and disabled
    disabledFillColor: PropTypes.string,
```

Any feedbacks on that functionality? 