### PR TITLE
range slider should update itself when props are updated

### DIFF
--- a/lib/mdl/RangeSlider.js
+++ b/lib/mdl/RangeSlider.js
@@ -52,6 +52,8 @@ class RangeSlider extends Component {
 
   componentWillReceiveProps(nextProps) {
     this._onThumbRadiiUpdate(nextProps);
+    this._setRange({ min: nextProps.minValue, max: nextProps.maxValue });
+    this._updateValue(this._range);
   }
 
   // region Property initializers


### PR DESCRIPTION
Bug: Range Slider, right now its not setting the new range provided through props and also not updating the view (after component is loaded).

Range Slider should update itself when props are updated after component is loaded. 
