### PR TITLE
Fixes small naming error

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,14 +331,14 @@ const Textfield = MKTextField.textfield()
 Customizing textfields through builder:
 
 ```jsx
-const ColoredTextfield = mdl.Textfield.textfield()
+const CustomTextfield = mdl.Textfield.textfield()
   .withPlaceholder(‘Text…’)
   .withStyle(styles.textfield)
   .withTintColor(MKColor.Lime)
   .withTextInputStyle({color: MKColor.Orange})
   .build();
 ...
-<CustomTexfield />
+<CustomTextfield />
 ```
 
 the jsx equivalent:


### PR DESCRIPTION
In the section about customizing text field, the name of the const and the component used in the example were different, fixed it.