### PR TITLE
fix for MKPropTypes not having a default export

### DIFF
--- a/lib/mdl/Ripple.js
+++ b/lib/mdl/Ripple.js
@@ -18,7 +18,7 @@ import {
   View,
 } from 'react-native';
 
-import MKPropTypes from '../MKPropTypes';
+import * as MKPropTypes from '../MKPropTypes';
 import MKTouchable from '../internal/MKTouchable';
 
 //

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -21,7 +21,7 @@ import {
   View,
 } from 'react-native';
 
-import MKPropTypes from '../MKPropTypes';
+import * as MKPropTypes from '../MKPropTypes';
 import MKColor from '../MKColor';
 import * as utils from '../utils';
 import { getTheme } from '../theme';


### PR DESCRIPTION
This fixes an inconsistency with ES6 module import syntax. Since there is no default export for MKPropTypes, this is sometimes undefined. 