### PR TITLE
fix "Can't tap into a field if I tap its placeholder, when floatingLbelEnabled={true}"

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -489,7 +489,7 @@ class Textfield extends Component {
 
   setPlaceholder(placeholder) {
     if(this.refs.input) {
-      this.refs.input.setNativeProps({ placeholder });  
+      this.refs.input.setNativeProps({ placeholder });
     }
   }
 
@@ -529,6 +529,7 @@ class Textfield extends Component {
 
     return (
       <View style={this.props.style} >
+        {floatingLabel}
         <TextInput  // the input
           ref="input"
           {...inputProps}
@@ -547,7 +548,6 @@ class Textfield extends Component {
           onBlur={this._onBlur}
           allowFontScaling={this.props.allowFontScaling}
         />
-        {floatingLabel}
         <Underline ref="underline"  // the underline
           {...underlineProps}
           underlineAniDur={this.props.floatingLabelAniDuration}


### PR DESCRIPTION
[Issue #208](https://github.com/xinthink/react-native-material-kit/issues/208).

When I tap on placeholder the input not focus, because is rendering before the floatingLabel. In react, which it is rendered first matter.