### PR TITLE
allow to disable ripple

### DIFF
--- a/lib/mdl/Ripple.js
+++ b/lib/mdl/Ripple.js
@@ -54,6 +54,9 @@ class Ripple extends Component {
 
   // Touch events handling
   _onTouchEvent = (evt) => {
+    if(!this.props.enabled){
+      return
+    }
     switch (evt.type) {
       case 'TOUCH_DOWN':
         this._onPointerDown(evt);
@@ -286,6 +289,9 @@ Ripple.propTypes = {
   onTouch: PropTypes.func,
 
   onLayout: PropTypes.func,
+  
+  // When set to false, Ripple will ignore triggered touches.
+  enabled: PropTypes.bool,
 };
 
 // ## <section id='defaults'>Defaults</section>
@@ -298,6 +304,7 @@ Ripple.defaultProps = {
   maskBorderRadius: 2,
   maskDuration: 200,
   shadowAniEnabled: true,
+  enabled: true,
 };
 
 


### PR DESCRIPTION
I noticed the ripple effect is still triggered even when a button is disabled.
Not sure if this is the best solution, but it works for my button case, where the `enabled=false` prop is passed down from the button.