### PR TITLE
Fix crash when toggling MKSwitch (RN0.33.0)

### DIFF
--- a/lib/mdl/Switch.js
+++ b/lib/mdl/Switch.js
@@ -219,7 +219,7 @@ class Switch extends Component {
   // Un-boxing the `Thumb` node from `AnimatedComponent`,
   // in order to access the component functions defined in `Thumb`
   getThumb() {
-    return this.refs.thumb.refs.node;
+    return this.refs.thumb._component;
   }
 
   // property initializers begin

--- a/lib/mdl/Switch.js
+++ b/lib/mdl/Switch.js
@@ -219,6 +219,9 @@ class Switch extends Component {
   // Un-boxing the `Thumb` node from `AnimatedComponent`,
   // in order to access the component functions defined in `Thumb`
   getThumb() {
+    if(typeof this.refs.thumb.refs.node !== "undefined"){
+      return this.refs.thumb.refs.node;
+    }
     return this.refs.thumb._component;
   }
 


### PR DESCRIPTION
This is to fix crash when toggling MKSwitch (RN0.33.0).
![switch_bug](https://cloud.githubusercontent.com/assets/2020693/18536403/3610605e-7b51-11e6-9464-364d7a552a95.png)
