### PR TITLE
[Textfield] check label._component is defined before making method call

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -82,7 +82,11 @@ class FloatingLabel extends Component {
   }
 
   measure(cb) {
-    return this.refs.label && this.refs.label._component.measure(cb);
+    const _measure = (this.refs.label._component !== undefined)
+      ? this.refs.label._component.measure(cb)
+      : this.refs.label.refs.node.measure(cb);
+
+    return this.refs.label && _measure;
   }
 
   aniFloatLabel() {


### PR DESCRIPTION
I ran into the issue mentioned in https://github.com/xinthink/react-native-material-kit/issues/233. 

As I'm using RN 0.29 and cannot upgrade to 0.33 any time soon and I'm sure there'd be some others people in the same boat, I think the library should facilitate to those cannot afford to upgrade RN.

This address the change introduced in patch https://github.com/xinthink/react-native-material-kit/pull/232