### PR TITLE
android/build.gradle: dependencies should be compile instead of provided

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    provided 'com.facebook.react:react-native:0.+'
+    compile 'com.facebook.react:react-native:0.+'
 }


### PR DESCRIPTION
Committing a change to fix https://github.com/xinthink/react-native-material-kit/issues/214
