### PR TITLE
Fix 2 underlines below MKTextField on Android

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -551,6 +551,7 @@ class Textfield extends Component {
           onFocus={this._onFocus}
           onBlur={this._onBlur}
           allowFontScaling={this.props.allowFontScaling}
+          underlineColorAndroid="transparent"
         />
         <Underline ref="underline"  // the underline
           {...underlineProps}


### PR DESCRIPTION
I think this happens only in newer React Native versions.