### PR TITLE
use UIManager.measure() instead of private refs

### DIFF
--- a/lib/internal/MKTouchable.js
+++ b/lib/internal/MKTouchable.js
@@ -12,7 +12,10 @@ import React, {
 import {
   requireNativeComponent,
   View,
+  NativeModules,
+  findNodeHandle,
 } from 'react-native';
+const UIManager = NativeModules.UIManager;
 
 import { convertCoordinate } from '../utils';
 
@@ -33,7 +36,7 @@ class MKTouchable extends Component {
   // endregion
 
   measure(cb) {
-    return this.refs.node.measure(cb);
+    return this.refs.node && UIManager.measure(findNodeHandle(this.refs.node), cb);
   }
 
   render() {

--- a/lib/mdl/Ripple.js
+++ b/lib/mdl/Ripple.js
@@ -16,7 +16,10 @@ import {
   Animated,
   Platform,
   View,
+  NativeModules,
+  findNodeHandle,
 } from 'react-native';
+const UIManager = NativeModules.UIManager;
 
 import * as MKPropTypes from '../MKPropTypes';
 import MKTouchable from '../internal/MKTouchable';
@@ -73,7 +76,7 @@ class Ripple extends Component {
   // property initializers end
 
   measure(cb) {
-    return this.refs.container.measure(cb);
+    return this.refs.container && UIManager.measure(findNodeHandle(this.refs.container), cb);
   }
 
   _onLayoutChange({ width, height }) {

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -19,7 +19,10 @@ import {
   Animated,
   TextInput,
   View,
+  NativeModules,
+  findNodeHandle,
 } from 'react-native';
+const UIManager = NativeModules.UIManager;
 
 import * as MKPropTypes from '../MKPropTypes';
 import MKColor from '../MKColor';
@@ -82,11 +85,7 @@ class FloatingLabel extends Component {
   }
 
   measure(cb) {
-    const _measure = (this.refs.label._component !== undefined)
-      ? this.refs.label._component.measure(cb)
-      : this.refs.label.refs.node.measure(cb);
-
-    return this.refs.label && _measure;
+    return this.refs.label && UIManager.measure(findNodeHandle(this.refs.label), cb);
   }
 
   aniFloatLabel() {


### PR DESCRIPTION
I was getting undefined `this.refs.label.refs.node.measure()` warnings on `FloatingLabel.measure()` so used `findNodeHandle` and `UIManager.measure()`, which also makes it safer from future updates perspective.