### PR TITLE
fix `no propType for native prop` error on Android on RN 0.36

### DIFF
--- a/lib/internal/MKTouchable.js
+++ b/lib/internal/MKTouchable.js
@@ -61,14 +61,16 @@ MKTouchable.propTypes = {
 
   // Touch events callback
   onTouch: PropTypes.func,
-
-  // FIXME `no propType for native prop` error on Android
-  nativeBackgroundAndroid: PropTypes.object,
 };
 
 const NativeTouchable = requireNativeComponent('MKTouchable', {
   name: 'MKTouchable',
   propTypes: MKTouchable.propTypes,
+}, {
+  nativeOnly: {
+    nativeBackgroundAndroid: true,
+    nativeForegroundAndroid: true,
+  },
 });
 
 // ## Public interface


### PR DESCRIPTION
Add `nativeBackgroundAndroid` and `nativeForegroundAndroid` (added in React-Native 0.36 [(6d175f2)](https://github.com/facebook/react-native/commit/6d175f2c257fe1acb1c36b15bc97bdb77560885c)) as nativeOnly props to fix `no propType for native prop` error on Android
