### PR TITLE
Added check to respect the disabled prop

### DIFF
--- a/lib/mdl/Ripple.js
+++ b/lib/mdl/Ripple.js
@@ -57,6 +57,10 @@ class Ripple extends Component {
 
   // Touch events handling
   _onTouchEvent = (evt) => {
+    if (this.props.disabled === true) {
+      return;
+    }
+    
     switch (evt.type) {
       case 'TOUCH_DOWN':
         this._onPointerDown(evt);


### PR DESCRIPTION
Currently, `Ripple` doesn't respect `disabled` prop. So, if you for example set `disabled` prop for `MKRadioButton` to true, it will still animate and change the visual state of the radio button (other components using Ripple might also be suffering from this). This change fixes it.