### PR TITLE
fixing an issue occuring due to a change made in v0.36

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -535,7 +535,6 @@ class Textfield extends Component {
           {...inputProps}
           style={[{
             backgroundColor: MKColor.Transparent,
-            flex: 1,
             alignSelf: 'stretch',
             paddingTop: 2, paddingBottom: 2,
             marginTop: this.state.inputMarginTop,


### PR DESCRIPTION
 (Fix unconstraint sizing in main axis), this allows the textinput to honor height and also does not trims down charachters like 'g & p'.
for more details please refer here https://github.com/facebook/react-native/commit/0a9b6bedb312eba22c5bc11498b1cc41363e5f27