### PR TITLE
Set default placeholderTextColor value to the tintColor

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -526,6 +526,7 @@ class Textfield extends Component {
       ...TextInput.propTypes,
       password: 1,
     });
+    const placeholderColor = inputProps.placeholderTextColor || underlineProps.tintColor;
 
     return (
       <View style={this.props.style} >
@@ -543,6 +544,7 @@ class Textfield extends Component {
           this.theme.textfieldStyle.textInputStyle,
           this.props.textInputStyle,
           ]}
+          placeholderTextColor={placeholderColor}
           onChangeText={this._onTextChange}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
@@ -597,7 +599,7 @@ Textfield.propTypes = {
   allowFontScaling: PropTypes.bool,
 
   // Additional props passed directly to the react native `TextInput` component
-  additionalInputProps: PropTypes.any
+  additionalInputProps: PropTypes.any,
 };
 
 // ## <section id='defaults'>Defaults</section>


### PR DESCRIPTION
The `tintColor` prop is described as `Color of the un-highlighted underline, and the placeholder`, but if you don't explicitly set the `placeholderTextColor`, it won't use the `tintColor`. Therefore I added a fallback to use the 'tintColor' when no 'placeholderTextColor' is provided to the `TextField` 😃 