### PR TITLE
Adds onPressIn, onPressOut events for slider

### DIFF
--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -68,6 +68,9 @@ class Slider extends Component {
     // Callback when value changed
     onChange: PropTypes.func,
 
+    // Callback when slider is pressed anywhere
+    onPressIn: PropTypes.func,
+
     // Callback when the value is confirmed
     onConfirm: PropTypes.func,
 
@@ -156,6 +159,12 @@ class Slider extends Component {
     }
   }
 
+  _emitOnPressIn() {
+    if(this.props.onPressIn) {
+      this.props.onPressIn();
+    }
+  }
+
   _emitConfirm() {
     if (this.props.onConfirm) {
       this.props.onConfirm(this._value);
@@ -186,8 +195,11 @@ class Slider extends Component {
 
   // Touch events handling
   _onTouchEvent(evt) {
+    console.log(evt)
     switch (evt.type) {
       case 'TOUCH_DOWN':
+        this._emitOnPressIn()
+        this._updateValueByTouch(evt);
       case 'TOUCH_MOVE':
         this._updateValueByTouch(evt);
         break;

--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -204,7 +204,6 @@ class Slider extends Component {
 
   // Touch events handling
   _onTouchEvent(evt) {
-    console.log(evt)
     switch (evt.type) {
       case 'TOUCH_DOWN':
         this._emitOnPressIn()

--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -71,6 +71,9 @@ class Slider extends Component {
     // Callback when slider is pressed anywhere
     onPressIn: PropTypes.func,
 
+    // Callback when slider stops being pressed
+    onPressOut: PropTypes.func,
+
     // Callback when the value is confirmed
     onConfirm: PropTypes.func,
 
@@ -165,6 +168,12 @@ class Slider extends Component {
     }
   }
 
+  _emitOnPressOut() {
+    if(this.props.onPressOut) {
+      this.props.onPressOut();
+    }
+  }
+
   _emitConfirm() {
     if (this.props.onConfirm) {
       this.props.onConfirm(this._value);
@@ -204,10 +213,12 @@ class Slider extends Component {
         this._updateValueByTouch(evt);
         break;
       case 'TOUCH_UP':
+        this._emitOnPressOut()
         this._confirmUpdateValueByTouch(evt);
         break;
       case 'TOUCH_CANCEL':
         // should not use the coordination inside a cancelled event
+        this._emitOnPressOut()
         this._confirmUpdateValueByTouch();
         break;
       default:

--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -163,13 +163,13 @@ class Slider extends Component {
   }
 
   _emitOnPressIn() {
-    if(this.props.onPressIn) {
+    if (this.props.onPressIn) {
       this.props.onPressIn();
     }
   }
 
   _emitOnPressOut() {
-    if(this.props.onPressOut) {
+    if (this.props.onPressOut) {
       this.props.onPressOut();
     }
   }
@@ -206,18 +206,19 @@ class Slider extends Component {
   _onTouchEvent(evt) {
     switch (evt.type) {
       case 'TOUCH_DOWN':
-        this._emitOnPressIn()
+        this._emitOnPressIn();
         this._updateValueByTouch(evt);
+        break;
       case 'TOUCH_MOVE':
         this._updateValueByTouch(evt);
         break;
       case 'TOUCH_UP':
-        this._emitOnPressOut()
+        this._emitOnPressOut();
         this._confirmUpdateValueByTouch(evt);
         break;
       case 'TOUCH_CANCEL':
         // should not use the coordination inside a cancelled event
-        this._emitOnPressOut()
+        this._emitOnPressOut();
         this._confirmUpdateValueByTouch();
         break;
       default:


### PR DESCRIPTION
Hi, I had a use case for the slider being in a swipeable interface. When you tried to use the slider, the page would swipe. An easy way to get around this was to add `onPressIn` and `onPressOut` events to the slider that disabled and enabled the page swiping, respectively.