### PR TITLE
Don't perform floating label animation when the input has a value

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -42,7 +42,7 @@ class FloatingLabel extends Component {
     this.offsetX = 0;
     this.placeholderHeight = 0;
     this.state = {
-      progress: new Animated.Value(1),
+      progress: new Animated.Value(props.isEmptyInput ? 1 : 0),
       opacity: new Animated.Value(0),
       text: '',
     };
@@ -196,6 +196,7 @@ FloatingLabel.propTypes = {
   tintColor: PropTypes.string,
   highlightColor: PropTypes.string,
   opacityAniDur: PropTypes.number,
+  isEmptyInput: PropTypes.bool,
 };
 
 FloatingLabel.defaultProps = {
@@ -514,6 +515,7 @@ class Textfield extends Component {
           {...props}
           text={this.props.placeholder}
           allowFontScaling={this.props.allowFontScaling}
+          isEmptyInput={!this.props.value}
         />
       );
     }


### PR DESCRIPTION
I just figured out that the animation is performed when the page is loaded and the input value is prefilled. I introduced a new prop that informs the floating label if it should play the animation or not on initialization.