### PR TITLE
feat(Switch): Added the elevation style prop for Thumb

### DIFF
--- a/lib/mdl/Switch.js
+++ b/lib/mdl/Switch.js
@@ -50,6 +50,7 @@ class Thumb extends Component {
       shadowRadius: 1,
       shadowOpacity: 0.7,
       shadowOffset: { width: 0, height: 1 },
+      elevation: 2,
     },
   };
 


### PR DESCRIPTION
For resolving [Switch doesn't have a thumb shadow](https://github.com/xinthink/react-native-material-kit/issues/303).

The `elevation` style prop has been used. [Docs](https://facebook.github.io/react-native/docs/view.html#style).

![screenshot from 2017-03-30 00-39-06](https://cloud.githubusercontent.com/assets/9950871/24477854/54848f90-14e1-11e7-8801-60e25c82bfc6.png)
