### PR TITLE
Thumb color not updated with prop change

### DIFF
--- a/lib/internal/Thumb.js
+++ b/lib/internal/Thumb.js
@@ -46,10 +46,7 @@ class Thumb extends Component {
     this._panResponder = {};
     this._animatedLeft = new Animated.Value(0);
     this._animatedScale = new Animated.Value(1);
-    this.state = {
-      color: LOWEST_VALUE_THUMB_COLOR,
-      borderColor: DEFAULT_UPPER_TRACK_COLOR,
-    };
+    this.state = { collapsed: true };
   }
 
   componentWillMount() {
@@ -68,9 +65,7 @@ class Thumb extends Component {
     });
 
     this._onRadiiUpdate(this.props);
-    this.setState({
-      borderColor: this.props.disabledColor,
-    });
+    this.setState({ collapsed: true });
   }
 
   componentDidMount() {
@@ -144,21 +139,34 @@ class Thumb extends Component {
   // from 'lowest' to 'non-lowest'
   _onExplode() {
     this.setState({
-      borderColor: this.props.enabledColor,
-      color: this.props.enabledColor,
+      collapsed: false
     });
   }
 
   // from 'non-lowest' to 'lowest'
   _onCollapse() {
-    this.setState({
-      borderColor: this.props.disabledColor,
-      color: LOWEST_VALUE_THUMB_COLOR,
-    });
+    this.setState({collapsed: true});
+  }
+
+  // define colors based on collapsed state
+  _getColors() {
+    let borderColor = DEFAULT_UPPER_TRACK_COLOR || this.props.disabledColor
+    , color = LOWEST_VALUE_THUMB_COLOR;
+
+    if (!this.state.collapsed) {
+      if (this.props.enabledColor) borderColor = this.props.enabledColor
+      if (this.props.enabledColor) color = this.props.enabledColor
+    }
+
+    return {
+      borderColor,
+      color
+    }
   }
 
   // Rendering the `Thumb`
   render() {
+    let {borderColor, color} = this._getColors()
     return (
       <Animated.View
         style={[  // the outer circle to draw the border
@@ -166,7 +174,7 @@ class Thumb extends Component {
           {
             width: this._containerDia,
             height: this._containerDia,
-            backgroundColor: this.state.borderColor,
+            backgroundColor: borderColor,
             borderRadius: this._containerRadii,
             position: 'absolute',
             left: this._animatedLeft,
@@ -187,7 +195,7 @@ class Thumb extends Component {
           style={{  // the inner circle
             width: this._dia,
             height: this._dia,
-            backgroundColor: this.state.color,
+            backgroundColor: color,
             borderRadius: this._radii,
             top: THUMB_BORDER_WIDTH,
             left: THUMB_BORDER_WIDTH,


### PR DESCRIPTION
The colors were stored in state and the state was not being recalculated on prop change. Rather then store the color in state it now calculates the colors on each render via `_getColors`. This function checks for the new `collapsed` state.