### PR TITLE
Fixed issue #215

### DIFF
--- a/lib/mdl/RadioButton.js
+++ b/lib/mdl/RadioButton.js
@@ -91,13 +91,30 @@ class RadioButton extends Component {
   componentWillMount() {
     this.group = this.props.group;
     this._initView(this.props.checked);
+
+    if (this.group && this.group.add instanceof Function)
+      this.group.add(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.group = nextProps.group;
+    if (this.group !== nextProps.group) {
+      if (this.group && this.group.remove instanceof Function)
+        this.group.remove(this);
+      
+      this.group = nextProps.group;
+
+      if (this.group && this.group.add instanceof Function)
+        this.group.add(this);
+    }
+
     if (nextProps.checked !== this.props.checked) {
       this._initView(nextProps.checked);
     }
+  }
+
+  componentWillUnmount() {
+    if (this.group && this.group.remove instanceof Function)
+      this.group.remove(this);
   }
 
   _initView(checked) {
@@ -222,40 +239,36 @@ class RadioButton extends Component {
   }
 }
 
-Object.defineProperty(RadioButton.prototype, 'group', {
-  // Set the group of this radio
-  set(group) {
-    this._group = group;
-    if (group) {
-      group.add(this);
-    }
-  },
-  // Retrieve the group of this radio
-  get() {
-    return this._group;
-  },
-  enumerable: true,
-});
-
-
 //
 // ## <section id='Group'>Group</section>
 // Managing a group of radio buttons.
 class Group {
-  constructor() {
+  constructor(onAdd, onRemove) {
     this.buttons = [];
+    this.onAdd = onAdd;
+    this.onRemove = onRemove;
   }
 
   add(btn) {
-    if (this.buttons.indexOf(btn) < 0) {
+    if (this.onAdd instanceof Function && this.onAdd(btn) === false)
+      return;
+
+    if (this.buttons.indexOf(btn) < 0)
       this.buttons.push(btn);
-    }
+  }
+
+  remove(btn) {
+    if (this.onRemove instanceof Function && this.onRemove(btn) === false)
+      return;
+
+    var index = this.buttons.indexOf(btn);
+    if (index >= 0)
+      this.buttons.splice(index, 1);
   }
 
   onChecked(btn, checked) {
-    if (checked) {
-      this.buttons.forEach((it) => it !== btn && it.confirmUncheck());
-    }
+    if (checked)
+      this.buttons.forEach((it) => (it !== btn) && it.confirmUncheck());
   }
 }
 


### PR DESCRIPTION
Fixed issue #215 RadioButton setState on unmounted components: causing possible memory leak, and setting states on components that may no longer exist or be mounted. Added events for Group onAdd and onRemove to group to allow user memory maps (for named Groups) to also be maintained. If onAdd or onRemove return false then the operation will be aborted... allowing the user to control which RadioButtons are allowed in / out of the group (if they so wish).