### PR TITLE
Replaced View.propTypes to ViewPropTypes

### DIFF
--- a/lib/internal/MKTouchable.js
+++ b/lib/internal/MKTouchable.js
@@ -11,8 +11,8 @@ import React, {
 
 import {
   requireNativeComponent,
-  View,
   NativeModules,
+  ViewPropTypes,
   findNodeHandle,
 } from 'react-native';
 const UIManager = NativeModules.UIManager;
@@ -57,7 +57,7 @@ class MKTouchable extends Component {
 // ## <section id='props'>Props</section>
 MKTouchable.propTypes = {
   // [RN.View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   // Touch events callback
   onTouch: PropTypes.func,

--- a/lib/internal/Thumb.js
+++ b/lib/internal/Thumb.js
@@ -17,6 +17,7 @@ import {
   Animated,
   PanResponder,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 // Default color of the upper part of the track
@@ -200,7 +201,7 @@ class Thumb extends Component {
 
 Thumb.propTypes = {
   // [RN.View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   // Callback to handle onPanResponderGrant gesture
   onGrant: PropTypes.func,

--- a/lib/internal/Tick.js
+++ b/lib/internal/Tick.js
@@ -14,13 +14,13 @@ import {
   requireNativeComponent,
   Animated,
   processColor,
-  View,
+  ViewPropTypes,
 } from 'react-native';
 
 // ## <section id='props'>Props</section>
 const PROP_TYPES = {
   // [View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   // Background color of the tick
   fillColor: PropTypes.any,

--- a/lib/mdl/IndeterminateProgress.js
+++ b/lib/mdl/IndeterminateProgress.js
@@ -15,6 +15,7 @@ import React, {
 
 import {
   Animated,
+  ViewPropTypes,
   Easing,
   View,
 } from 'react-native';
@@ -30,7 +31,7 @@ class IndeterminateProgress extends Component {
   // ## <section id='Props'>Props</section>
   static propTypes = {
     // [View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-    ...View.propTypes,
+    ...ViewPropTypes,
 
     // Color of the progress layer
     progressColor: PropTypes.string,

--- a/lib/mdl/Progress.js
+++ b/lib/mdl/Progress.js
@@ -16,6 +16,7 @@ import React, {
 import {
   Animated,
   Easing,
+  ViewPropTypes,
   View,
 } from 'react-native';
 
@@ -30,7 +31,7 @@ class Progress extends Component {
   // ## <section id='props'>Props</section>
   static propTypes = {
     // [View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-    ...View.propTypes,
+    ...ViewPropTypes,
 
     // Initial value of progress, Number: [0, 1.0]
     progress: PropTypes.number,

--- a/lib/mdl/RangeSlider.js
+++ b/lib/mdl/RangeSlider.js
@@ -15,6 +15,7 @@ import React, {
 import {
   Animated,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 import { getTheme } from '../theme';
@@ -389,7 +390,7 @@ Object.defineProperty(RangeSlider.prototype, 'maxValue', {
 // ## <section id='props'>Props</section>
 RangeSlider.propTypes = {
   // [RN.View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   // Minimum value of the range, default is `0`
   min: PropTypes.number,

--- a/lib/mdl/Ripple.js
+++ b/lib/mdl/Ripple.js
@@ -15,7 +15,7 @@ import React, {
 import {
   Animated,
   Platform,
-  View,
+  ViewPropTypes,
   NativeModules,
   findNodeHandle,
 } from 'react-native';
@@ -261,7 +261,7 @@ class Ripple extends Component {
 // ## <section id='props'>Props</section>
 Ripple.propTypes = {
   // [RN.View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   // Color of the `Ripple` layer
   rippleColor: PropTypes.string,

--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -15,6 +15,7 @@ import React, {
 
 import {
   Animated,
+  ViewPropTypes,
   PanResponder,
   View,
 } from 'react-native';
@@ -39,7 +40,7 @@ class Slider extends Component {
   // ## <section id='props'>Props</section>
   static propTypes = {
     // [RN.View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-    ...View.propTypes,
+    ...ViewPropTypes,
 
     // Minimum value of the range, default is `0`
     min: PropTypes.number,

--- a/lib/mdl/Spinner.android.js
+++ b/lib/mdl/Spinner.android.js
@@ -16,7 +16,7 @@ import React, {
 
 import {
   requireNativeComponent,
-  View,
+  ViewPropTypes,
 } from 'react-native';
 
 import { getTheme } from '../theme';
@@ -25,7 +25,7 @@ import * as utils from '../utils';
 // ## <section id='props'>Props</section>
 const PROP_TYPES = {
   // [View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   // Colors of the progress stroke
   // - {`Array`|`String`} can be a list of colors

--- a/lib/mdl/Switch.js
+++ b/lib/mdl/Switch.js
@@ -20,6 +20,7 @@ import {
   Animated,
   TouchableWithoutFeedback,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 import MKColor from '../MKColor';
@@ -32,7 +33,7 @@ import { getTheme } from '../theme';
 class Thumb extends Component {
   static propTypes = {
     // [View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-    ...View.propTypes,
+    ...ViewPropTypes,
     checked: PropTypes.bool,
     onColor: PropTypes.string,
     offColor: PropTypes.string,


### PR DESCRIPTION
React native moved View.propTypes to ViewPropTypes. This pr makes that change, solving the warnings in console. 

See commit here https://github.com/facebook/react-native/commit/53905a537a58d028fc5eb1c4e9a8ec967d8cd396