### PR TITLE
ViewPropTypes fix for react native

### DIFF
--- a/lib/internal/MKTouchable.js
+++ b/lib/internal/MKTouchable.js
@@ -12,12 +12,11 @@ import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   NativeModules,
-  ViewPropTypes,
   findNodeHandle,
 } from 'react-native';
 const UIManager = NativeModules.UIManager;
 
-import { convertCoordinate } from '../utils';
+import { convertCoordinate, ViewPropTypes } from '../utils';
 
 //
 // ## <section id='MKTouchable'>MKTouchable</section>

--- a/lib/internal/Thumb.js
+++ b/lib/internal/Thumb.js
@@ -12,12 +12,12 @@ import React, {
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from '../utils';
 
 import {
   Animated,
   PanResponder,
   View,
-  ViewPropTypes,
 } from 'react-native';
 
 // Default color of the upper part of the track

--- a/lib/internal/Tick.js
+++ b/lib/internal/Tick.js
@@ -9,12 +9,12 @@ import React, {
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from '../utils';
 
 import {
   requireNativeComponent,
   Animated,
   processColor,
-  ViewPropTypes,
 } from 'react-native';
 
 // ## <section id='props'>Props</section>

--- a/lib/mdl/IndeterminateProgress.js
+++ b/lib/mdl/IndeterminateProgress.js
@@ -12,10 +12,10 @@ import React, {
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from '../utils';
 
 import {
   Animated,
-  ViewPropTypes,
   Easing,
   View,
 } from 'react-native';

--- a/lib/mdl/Progress.js
+++ b/lib/mdl/Progress.js
@@ -12,11 +12,11 @@ import React, {
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from '../utils';
 
 import {
   Animated,
   Easing,
-  ViewPropTypes,
   View,
 } from 'react-native';
 

--- a/lib/mdl/RangeSlider.js
+++ b/lib/mdl/RangeSlider.js
@@ -11,11 +11,11 @@ import React, {
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from '../utils';
 
 import {
   Animated,
   View,
-  ViewPropTypes,
 } from 'react-native';
 
 import { getTheme } from '../theme';

--- a/lib/mdl/Ripple.js
+++ b/lib/mdl/Ripple.js
@@ -11,11 +11,11 @@ import React, {
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from '../utils';
 
 import {
   Animated,
   Platform,
-  ViewPropTypes,
   NativeModules,
   findNodeHandle,
 } from 'react-native';

--- a/lib/mdl/Slider.js
+++ b/lib/mdl/Slider.js
@@ -12,10 +12,10 @@ import React, {
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from '../utils';
 
 import {
   Animated,
-  ViewPropTypes,
   PanResponder,
   View,
 } from 'react-native';

--- a/lib/mdl/Spinner.android.js
+++ b/lib/mdl/Spinner.android.js
@@ -16,7 +16,6 @@ import PropTypes from 'prop-types';
 
 import {
   requireNativeComponent,
-  ViewPropTypes,
 } from 'react-native';
 
 import { getTheme } from '../theme';
@@ -25,7 +24,7 @@ import * as utils from '../utils';
 // ## <section id='props'>Props</section>
 const PROP_TYPES = {
   // [View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-  ...ViewPropTypes,
+  ...utils.ViewPropTypes,
 
   // Colors of the progress stroke
   // - {`Array`|`String`} can be a list of colors

--- a/lib/mdl/Spinner.ios.js
+++ b/lib/mdl/Spinner.ios.js
@@ -13,6 +13,7 @@ import React, {
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from '../utils';
 
 import {
   Animated,
@@ -59,7 +60,7 @@ class Spinner extends Component {
   // ## <section id='props'>Props</section>
   static propTypes = {
     // [View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-    ...View.propTypes,
+    ...ViewPropTypes,
 
     // Colors of the progress stroke
     // - {`Array`|`String`} can be a list of colors

--- a/lib/mdl/Switch.js
+++ b/lib/mdl/Switch.js
@@ -20,7 +20,6 @@ import {
   Animated,
   TouchableWithoutFeedback,
   View,
-  ViewPropTypes,
 } from 'react-native';
 
 import MKColor from '../MKColor';
@@ -33,7 +32,7 @@ import { getTheme } from '../theme';
 class Thumb extends Component {
   static propTypes = {
     // [View Props](https://facebook.github.io/react-native/docs/view.html#props)...
-    ...ViewPropTypes,
+    ...utils.ViewPropTypes,
     checked: PropTypes.bool,
     onColor: PropTypes.string,
     offColor: PropTypes.string,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,8 @@ import {
   TouchableWithoutFeedback,
   Platform,
   processColor,
+  View,
+  ViewPropTypes as RNViewPropTypes,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import * as R from 'ramda';
@@ -66,6 +68,7 @@ function extractTouchableProps(view) {
   });
 }
 
+const ViewPropTypes = RNViewPropTypes || View.propTypes;
 
 // ## Public interface
 export {
@@ -78,4 +81,5 @@ export {
   extractPropsBy,
   extractTouchableProps,
   processColor as parseColor,  // parse stringified color as int
+  ViewPropTypes,
 };


### PR DESCRIPTION
Another PR has already made the ViewPropTypes fix for new versions of react native. However that fix broke support with older versions of react. (Since they don't have ViewPropTypes). 

This PR fixes that, by using ViewPropTypes for newer versions and falls back to View.propTypes for older versions