### PR TITLE
handle RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/github/xinthink/rnmk/ReactMaterialKitPackage.java
+++ b/android/src/main/java/com/github/xinthink/rnmk/ReactMaterialKitPackage.java
@@ -22,7 +22,7 @@ public class ReactMaterialKitPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
RN 0.47 removed createJSModules from ReactPackage [commit](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)