### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ const SliderWithValue = mdl.Slider.slider()
   .build();
 …
 <SliderWithValue
-  ref=“sliderWithValue”
+  ref="sliderWithValue"
   onChange={(curValue) => this.setState({curValue})}
 />
 ```
@@ -316,7 +316,7 @@ const SliderWithRange = mdl.RangeSlider.slider()
   .build();
 …
 <SliderWithRange
-  ref=“sliderWithRange”
+  ref="sliderWithRange"
   onChange={(curValue) => this.setState({
     min: curValue.min,
     max: curValue.max,
@@ -359,7 +359,7 @@ Customizing textfields through builder:
 
 ```jsx
 const CustomTextfield = mdl.Textfield.textfield()
-  .withPlaceholder(‘Text…’)
+  .withPlaceholder("Text...")
   .withStyle(styles.textfield)
   .withTintColor(MKColor.Lime)
   .withTextInputStyle({color: MKColor.Orange})


### PR DESCRIPTION
The examples are using a different quote ” (U+201D : RIGHT DOUBLE QUOTATION MARK {double comma quotation mark}) to what is expected " (U+0022 : QUOTATION MARK) which results in compile-time errors. This fixes the occurrences I found in the examples.