### PR TITLE
Fix/ Issue when placeholder is gone in multiline mode

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -338,7 +338,8 @@ class Textfield extends Component {
   }
 
   get bufferedValue() {
-    return (this._bufferedValue || '').trim();
+    var bufferValue = this._bufferedValue.toString() || '';
+    return bufferValue.trim();
   }
 
   focus() {

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -490,7 +490,7 @@ class Textfield extends Component {
 
   setPlaceholder(placeholder) {
     if (this.refs.input) {
-      this.refs.input.setNativeProps({ placeholder });
+      this.refs.input.setNativeProps({ placeholder: placeholder || ' ' });
     }
   }
 

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -367,6 +367,9 @@ class Textfield extends Component {
     const newText = nextProps.value || nextProps.text || nextProps.defaultValue;
     if (newText) {
       this.bufferedValue = newText;
+    } else if (!nextProps.isFocused) {
+      this.bufferedValue = '';
+      this._aniStopHighlight();
     }
     this._originPlaceholder = nextProps.placeholder;
   }

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -441,7 +441,7 @@ class Textfield extends Component {
   _aniStartHighlight(focused) {
     if (this.props.floatingLabelEnabled) {
       // hide fixed placeholder, if floating
-      this.setPlaceholder('');
+      this.setPlaceholder(' ');
 
       // and show floating label
       // FIXME workaround https://github.com/facebook/react-native/issues/3220
@@ -490,7 +490,7 @@ class Textfield extends Component {
 
   setPlaceholder(placeholder) {
     if (this.refs.input) {
-      this.refs.input.setNativeProps({ placeholder: placeholder || ' ' });
+      this.refs.input.setNativeProps({ placeholder });
     }
   }
 

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -326,6 +326,7 @@ class Textfield extends Component {
     this.anim = null;
     this.state = {
       inputMarginTop: 0,
+      layout: {},
     };
   }
 
@@ -371,7 +372,7 @@ class Textfield extends Component {
   }
 
   componentDidMount() {
-    requestAnimationFrame(this._doMeasurement.bind(this));
+    // requestAnimationFrame(this._doMeasurement.bind(this));
   }
 
   // property initializers begin
@@ -402,6 +403,18 @@ class Textfield extends Component {
     this.anim = Animated.parallel(animations).start(cb);
   }
 
+  onLayout(event) {
+    const { x, y, height, width } = event.nativeEvent.layout;
+    const newLayout = {
+      height,
+      width,
+      left: x,
+      top: y,
+    };
+    this.setState({ layout: newLayout });
+    this._doMeasurement();
+  }
+
   _doMeasurement() {
     if (this.refs.input) {
       this.refs.input.measure(this._onInputMeasured.bind(this));
@@ -415,7 +428,8 @@ class Textfield extends Component {
     this.setState({ inputMarginTop: height });
   }
 
-  _onInputMeasured(left, top, width, height) {
+  _onInputMeasured() {
+    const {  left, top, width, height } = this.state.layout;
     Object.assign(this.inputFrame, { left, top, width, height });
     this.refs.underline.updateLineLength(width, () => {
       if (this.bufferedValue || this.isFocused()) {
@@ -528,7 +542,10 @@ class Textfield extends Component {
     });
 
     return (
-      <View style={this.props.style} >
+      <View
+        style={this.props.style}
+        onLayout={event => this.onLayout(event)}
+      >
         {floatingLabel}
         <TextInput  // the input
           ref="input"

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -233,11 +233,11 @@ class Underline extends Component {
     return [
       Animated.timing(this.animatedLeft, {
         toValue: 0,
-        duration: this.props.underlineAniDur,
+        duration: 0,
       }),
       Animated.timing(this.animatedLineLength, {
         toValue: this.state.lineLength,
-        duration: this.props.underlineAniDur,
+        duration: 0,
       }),
     ];
   }
@@ -369,6 +369,11 @@ class Textfield extends Component {
       this.bufferedValue = newText;
     } else if (!nextProps.isFocused) {
       this.bufferedValue = '';
+    }
+    if (nextProps.isFocused) {
+      this._aniStartHighlight(true);
+    }
+    if(!nextProps.isFocused){
       this._aniStopHighlight();
     }
     this._originPlaceholder = nextProps.placeholder;
@@ -387,12 +392,12 @@ class Textfield extends Component {
   };
 
   _onFocus = (e) => {
-    this._aniStartHighlight(true);
+    // this._aniStartHighlight(true);
     this._callback('onFocus', e);
   };
 
   _onBlur = (e) => {
-    this._aniStopHighlight();
+    // this._aniStopHighlight();
     this._callback('onBlur', e);
   };
 

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -21,6 +21,7 @@ import {
   View,
   NativeModules,
   findNodeHandle,
+  Platform,
 } from 'react-native';
 const UIManager = NativeModules.UIManager;
 
@@ -542,6 +543,10 @@ class Textfield extends Component {
       password: 1,
     });
 
+    const  autoGrow = this.props && Platform.OS === 'android';
+    const autoGrowHeigt = this.state.height || 45;
+    const paddingBottomStyle =  this.props.textInputStyle.paddingBottom || 0;
+
     return (
       <View
         style={this.props.style}
@@ -560,8 +565,16 @@ class Textfield extends Component {
           },
           this.theme.textfieldStyle.textInputStyle,
           this.props.textInputStyle,
+          autoGrow ? { height: autoGrowHeigt } : null,
           ]}
           onChangeText={this._onTextChange}
+          onChange={(event) => {
+            if(autoGrow){
+              this.setState({
+                height: event.nativeEvent.contentSize.height + paddingBottomStyle,
+              });
+            }
+          }}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
           allowFontScaling={this.props.allowFontScaling}

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -480,7 +480,7 @@ class Textfield extends Component {
 
           // and hide floating label
           // FIXME workaround https://github.com/facebook/react-native/issues/3220
-          if (!this.bufferedValue) {
+          if (!this.bufferedValue && this.refs.floatingLabel) {
             this.refs.floatingLabel.updateText('');
           }
         }

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -21,7 +21,6 @@ import {
   View,
   NativeModules,
   findNodeHandle,
-  Platform,
 } from 'react-native';
 const UIManager = NativeModules.UIManager;
 
@@ -543,10 +542,6 @@ class Textfield extends Component {
       password: 1,
     });
 
-    const  autoGrow = this.props && Platform.OS === 'android';
-    const autoGrowHeigt = this.state.height || 45;
-    const paddingBottomStyle =  this.props.textInputStyle.paddingBottom || 0;
-
     return (
       <View
         style={this.props.style}
@@ -565,16 +560,8 @@ class Textfield extends Component {
           },
           this.theme.textfieldStyle.textInputStyle,
           this.props.textInputStyle,
-          autoGrow ? { height: autoGrowHeigt } : null,
           ]}
           onChangeText={this._onTextChange}
-          onChange={(event) => {
-            if(autoGrow){
-              this.setState({
-                height: event.nativeEvent.contentSize.height + paddingBottomStyle,
-              });
-            }
-          }}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
           allowFontScaling={this.props.allowFontScaling}

--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -10,26 +10,24 @@
 // Created by ywu on 15/8/3.
 //
 
-import React, {
-  Component,
-} from 'react';
-import PropTypes from 'prop-types';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import {
   Animated,
   TextInput,
   View,
   NativeModules,
-  findNodeHandle,
-} from 'react-native';
+  findNodeHandle
+} from "react-native";
 const UIManager = NativeModules.UIManager;
 
-import * as MKPropTypes from '../MKPropTypes';
-import MKColor from '../MKColor';
-import * as utils from '../utils';
-import { getTheme } from '../theme';
+import * as MKPropTypes from "../MKPropTypes";
+import MKColor from "../MKColor";
+import * as utils from "../utils";
+import { getTheme } from "../theme";
 
-import { pick } from 'ramda';
+import { pick } from "ramda";
 
 //
 // ## <section id='FloatingLabel'>FloatingLabel</section>
@@ -44,7 +42,7 @@ class FloatingLabel extends Component {
     this.state = {
       progress: new Animated.Value(1),
       opacity: new Animated.Value(0),
-      text: '',
+      text: ""
     };
   }
 
@@ -64,7 +62,7 @@ class FloatingLabel extends Component {
     const height = layout.height;
 
     if (width && !this.offsetX) {
-      this.offsetX = ((width - (width * 0.8)) / 2 * -1) - x;
+      this.offsetX = (width - width * 0.8) / 2 * -1 - x;
     }
 
     if (height && !this.placeholderHeight) {
@@ -83,7 +81,9 @@ class FloatingLabel extends Component {
   }
 
   measure(cb) {
-    return this.refs.label && UIManager.measure(findNodeHandle(this.refs.label), cb);
+    return (
+      this.refs.label && UIManager.measure(findNodeHandle(this.refs.label), cb)
+    );
   }
 
   aniFloatLabel() {
@@ -91,16 +91,18 @@ class FloatingLabel extends Component {
       return [];
     }
 
-    return [Animated.sequence([
-      Animated.timing(this.state.opacity, {
-        toValue: 1,
-        duration: this.props.opacityAniDur,
-      }),
-      Animated.timing(this.state.progress, {
-        toValue: 0,
-        duration: this.props.floatingLabelAniDuration,
-      }),
-    ])];
+    return [
+      Animated.sequence([
+        Animated.timing(this.state.opacity, {
+          toValue: 1,
+          duration: this.props.opacityAniDur
+        }),
+        Animated.timing(this.state.progress, {
+          toValue: 0,
+          duration: this.props.floatingLabelAniDuration
+        })
+      ])
+    ];
   }
 
   aniSinkLabel() {
@@ -108,37 +110,39 @@ class FloatingLabel extends Component {
       return [];
     }
 
-    return [Animated.sequence([
-      Animated.timing(this.state.progress, {
-        toValue: 1,
-        duration: this.props.floatingLabelAniDuration,
-      }),
-      Animated.timing(this.state.opacity, {
-        toValue: 0,
-        duration: this.props.opacityAniDur,
-      }),
-    ])];
+    return [
+      Animated.sequence([
+        Animated.timing(this.state.progress, {
+          toValue: 1,
+          duration: this.props.floatingLabelAniDuration
+        }),
+        Animated.timing(this.state.opacity, {
+          toValue: 0,
+          duration: this.props.opacityAniDur
+        })
+      ])
+    ];
   }
 
   render() {
     const labelColor = this.state.progress.interpolate({
       inputRange: [0, 1],
-      outputRange: [this.props.highlightColor, this.props.tintColor],
+      outputRange: [this.props.highlightColor, this.props.tintColor]
     });
 
     const labelScale = this.state.progress.interpolate({
       inputRange: [0, 1],
-      outputRange: [0.8, 1],
+      outputRange: [0.8, 1]
     });
 
     const labelY = this.state.progress.interpolate({
       inputRange: [0, 1],
-      outputRange: [0, this.placeholderHeight],
+      outputRange: [0, this.placeholderHeight]
     });
 
     const labelX = this.state.progress.interpolate({
       inputRange: [0, 1],
-      outputRange: [this.offsetX, 0],
+      outputRange: [this.offsetX, 0]
     });
 
     return (
@@ -146,21 +150,19 @@ class FloatingLabel extends Component {
         ref="label"
         pointerEvents="none"
         allowFontScaling={this.props.allowFontScaling}
-
-        style={[{
-          backgroundColor: MKColor.Transparent,
-          position: 'absolute',
-          top: labelY,
-          left: labelX,
-          color: labelColor,
-          opacity: this.state.opacity,
-          fontSize: 16,
-          transform: [
-            { scale: labelScale },
-          ],
-          marginBottom: this.props.floatingLabelBottomMargin,
-        },
-        this.props.floatingLabelFont,
+        style={[
+          {
+            backgroundColor: MKColor.Transparent,
+            position: "absolute",
+            top: labelY,
+            left: labelX,
+            color: labelColor,
+            opacity: this.state.opacity,
+            fontSize: 16,
+            transform: [{ scale: labelScale }],
+            marginBottom: this.props.floatingLabelBottomMargin
+          },
+          this.props.floatingLabelFont
         ]}
         onLayout={this._onLabelLayout}
       >
@@ -186,7 +188,7 @@ FloatingLabel.publicPropTypes = {
   floatingLabelFont: MKPropTypes.font,
 
   // Specifies should fonts scale to respect Text Size accessibility setting on iOS.
-  allowFontScaling: PropTypes.bool,
+  allowFontScaling: PropTypes.bool
 };
 
 FloatingLabel.propTypes = {
@@ -195,14 +197,13 @@ FloatingLabel.propTypes = {
   // internal props
   tintColor: PropTypes.string,
   highlightColor: PropTypes.string,
-  opacityAniDur: PropTypes.number,
+  opacityAniDur: PropTypes.number
 };
 
 FloatingLabel.defaultProps = {
   floatingLabelAniDuration: 200,
-  opacityAniDur: 0,
+  opacityAniDur: 0
 };
-
 
 //
 // ## <section id='Underline'>Underline</section>
@@ -214,7 +215,7 @@ class Underline extends Component {
     this.animatedLeft = new Animated.Value(0);
     this.animatedLineLength = new Animated.Value(0);
     this.state = {
-      lineLength: 0,
+      lineLength: 0
     };
   }
 
@@ -233,12 +234,12 @@ class Underline extends Component {
     return [
       Animated.timing(this.animatedLeft, {
         toValue: 0,
-        duration: 0,
+        duration: 0
       }),
       Animated.timing(this.animatedLineLength, {
         toValue: this.state.lineLength,
-        duration: 0,
-      }),
+        duration: 0
+      })
     ];
   }
 
@@ -251,43 +252,47 @@ class Underline extends Component {
     return [
       Animated.timing(this.animatedLeft, {
         toValue: this.state.lineLength / 2,
-        duration: this.props.underlineAniDur,
+        duration: this.props.underlineAniDur
       }),
       Animated.timing(this.animatedLineLength, {
         toValue: 0,
-        duration: this.props.underlineAniDur,
-      }),
+        duration: this.props.underlineAniDur
+      })
     ];
   }
 
   // the colorful forefront line, animation enabled
   renderUnderline() {
-    return this.props.underlineEnabled && (
-      <Animated.View
-        style={{
-          position: 'absolute',
-          backgroundColor: this.props.highlightColor,
-          height: this.props.underlineSize,
-          left: this.animatedLeft,
-          width: this.animatedLineLength,
-        }}
-      />);
+    return (
+      this.props.underlineEnabled && (
+        <Animated.View
+          style={{
+            position: "absolute",
+            backgroundColor: this.props.highlightColor,
+            height: this.props.underlineSize,
+            left: this.animatedLeft,
+            width: this.animatedLineLength
+          }}
+        />
+      )
+    );
   }
 
   render() {
     return (
-      <View pointerEvents="none"
+      <View
+        pointerEvents="none"
         style={{
           // top: -this.props.underlineSize,
-          height: this.props.underlineSize,
+          height: this.props.underlineSize
         }}
       >
-        <View  // the default silver border
+        <View // the default silver border
           style={{
-            position: 'absolute',
+            position: "absolute",
             backgroundColor: this.props.tintColor,
             height: this.props.underlineSize,
-            width: this.state.lineLength,
+            width: this.state.lineLength
           }}
         />
         {this.renderUnderline()}
@@ -302,15 +307,14 @@ Underline.propTypes = {
   tintColor: PropTypes.string,
   highlightColor: PropTypes.string,
   underlineSize: PropTypes.number,
-  underlineAniDur: PropTypes.number,
+  underlineAniDur: PropTypes.number
 };
 
 Underline.defaultProps = {
   underlineEnabled: true,
   underlineAniDur: FloatingLabel.defaultProps.floatingLabelAniDuration,
-  underlineSize: 2,
+  underlineSize: 2
 };
-
 
 //
 // ## <section id='Textfield'>Textfield</section>
@@ -326,7 +330,7 @@ class Textfield extends Component {
     this.anim = null;
     this.state = {
       inputMarginTop: 0,
-      layout: {},
+      layout: {}
     };
   }
 
@@ -338,8 +342,9 @@ class Textfield extends Component {
   }
 
   get bufferedValue() {
-    var bufferValue = this._bufferedValue.toString() || '';
-    return bufferValue.trim();
+    var bufferValue = this._bufferedValue || "";
+    if (bufferValue.trim) return bufferValue.trim();
+    return "";
   }
 
   focus() {
@@ -359,8 +364,8 @@ class Textfield extends Component {
   }
 
   componentWillMount() {
-    this.bufferedValue = this.props.value || this.props.text ||
-    this.props.defaultValue;
+    this.bufferedValue =
+      this.props.value || this.props.text || this.props.defaultValue;
     this._originPlaceholder = this.props.placeholder;
   }
 
@@ -369,12 +374,12 @@ class Textfield extends Component {
     if (newText) {
       this.bufferedValue = newText;
     } else if (!nextProps.isFocused) {
-      this.bufferedValue = '';
+      this.bufferedValue = "";
     }
     if (nextProps.isFocused) {
       this._aniStartHighlight(true);
     }
-    if(!nextProps.isFocused){
+    if (!nextProps.isFocused) {
       this._aniStopHighlight();
     }
     this._originPlaceholder = nextProps.placeholder;
@@ -386,20 +391,20 @@ class Textfield extends Component {
 
   // property initializers begin
 
-  _onTextChange = (text) => {
+  _onTextChange = text => {
     this.bufferedValue = text;
-    this._callback('onTextChange', text);
-    this._callback('onChangeText', text);
+    this._callback("onTextChange", text);
+    this._callback("onChangeText", text);
   };
 
-  _onFocus = (e) => {
+  _onFocus = e => {
     // this._aniStartHighlight(true);
-    this._callback('onFocus', e);
+    this._callback("onFocus", e);
   };
 
-  _onBlur = (e) => {
+  _onBlur = e => {
     // this._aniStopHighlight();
-    this._callback('onBlur', e);
+    this._callback("onBlur", e);
   };
 
   // property initializers end
@@ -418,7 +423,7 @@ class Textfield extends Component {
       height,
       width,
       left: x,
-      top: y,
+      top: y
     };
     this.setState({ layout: newLayout });
     this._doMeasurement();
@@ -438,11 +443,11 @@ class Textfield extends Component {
   }
 
   _onInputMeasured() {
-    const {  left, top, width, height } = this.state.layout;
+    const { left, top, width, height } = this.state.layout;
     Object.assign(this.inputFrame, { left, top, width, height });
     this.refs.underline.updateLineLength(width, () => {
       if (this.bufferedValue || this.isFocused()) {
-        this._aniStartHighlight(this.isFocused());  // if input not empty, lift the label
+        this._aniStartHighlight(this.isFocused()); // if input not empty, lift the label
       }
     });
   }
@@ -464,7 +469,7 @@ class Textfield extends Component {
   _aniStartHighlight(focused) {
     if (this.props.floatingLabelEnabled) {
       // hide fixed placeholder, if floating
-      this.setPlaceholder(' ');
+      this.setPlaceholder(" ");
 
       // and show floating label
       // FIXME workaround https://github.com/facebook/react-native/issues/3220
@@ -505,7 +510,7 @@ class Textfield extends Component {
           // and hide floating label
           // FIXME workaround https://github.com/facebook/react-native/issues/3220
           if (!this.bufferedValue && this.refs.floatingLabel) {
-            this.refs.floatingLabel.updateText('');
+            this.refs.floatingLabel.updateText("");
           }
         }
       });
@@ -530,11 +535,13 @@ class Textfield extends Component {
     if (this.props.floatingLabelEnabled) {
       // the floating label
       const props = Object.assign(
-        pick(['tintColor', 'highlightColor', 'floatingLabelFont'], tfTheme),
-        utils.extractProps(this, FloatingLabel.propTypes));
+        pick(["tintColor", "highlightColor", "floatingLabelFont"], tfTheme),
+        utils.extractProps(this, FloatingLabel.propTypes)
+      );
 
       floatingLabel = (
-        <FloatingLabel ref="floatingLabel"
+        <FloatingLabel
+          ref="floatingLabel"
           {...props}
           text={this.props.placeholder}
           allowFontScaling={this.props.allowFontScaling}
@@ -543,32 +550,36 @@ class Textfield extends Component {
     }
 
     const underlineProps = Object.assign(
-      pick(['tintColor', 'highlightColor'], tfTheme),
-      utils.extractProps(this, ['tintColor',
-        'highlightColor', 'underlineSize', 'underlineEnabled']));
+      pick(["tintColor", "highlightColor"], tfTheme),
+      utils.extractProps(this, [
+        "tintColor",
+        "highlightColor",
+        "underlineSize",
+        "underlineEnabled"
+      ])
+    );
     const inputProps = utils.extractProps(this, {
       ...TextInput.propTypes,
-      password: 1,
+      password: 1
     });
 
     return (
-      <View
-        style={this.props.style}
-        onLayout={event => this.onLayout(event)}
-      >
+      <View style={this.props.style} onLayout={event => this.onLayout(event)}>
         {floatingLabel}
-        <TextInput  // the input
+        <TextInput // the input
           ref="input"
           {...inputProps}
           {...this.props.additionalInputProps}
-          style={[{
-            backgroundColor: MKColor.Transparent,
-            alignSelf: 'stretch',
-            paddingTop: 2, paddingBottom: 2,
-            marginTop: this.state.inputMarginTop,
-          },
-          this.theme.textfieldStyle.textInputStyle,
-          this.props.textInputStyle,
+          style={[
+            {
+              backgroundColor: MKColor.Transparent,
+              alignSelf: "stretch",
+              paddingTop: 2,
+              paddingBottom: 2,
+              marginTop: this.state.inputMarginTop
+            },
+            this.theme.textfieldStyle.textInputStyle,
+            this.props.textInputStyle
           ]}
           onChangeText={this._onTextChange}
           onFocus={this._onFocus}
@@ -577,7 +588,8 @@ class Textfield extends Component {
           secureTextEntry={this.props.password}
           underlineColorAndroid="transparent"
         />
-        <Underline ref="underline"  // the underline
+        <Underline
+          ref="underline" // the underline
           {...underlineProps}
           underlineAniDur={this.props.floatingLabelAniDuration}
         />
@@ -635,7 +647,7 @@ Textfield.defaultProps = {
   //   fontSize: getTheme().fontSize - 2,
   // },
   style: {
-    height: 39,
+    height: 39
   },
   // textInputStyle: {
   //   color: getTheme().fontColor,
@@ -643,28 +655,26 @@ Textfield.defaultProps = {
   //   paddingLeft: 0,
   //   paddingRight: 0,
   // },
-  underlineEnabled: true,
+  underlineEnabled: true
 };
-
 
 // --------------------------
 // Builder
 //
-const {
-  Builder,
-} = require('../builder');
+const { Builder } = require("../builder");
 
 //
 // ## Textfield builder
 //
 class TextfieldBuilder extends Builder {
-
   // For compatibility with RN version older than 0.9.0.
   // > Since [RN v0.9.0][], `TextInput` became a [controlled component][]
   // [RN v0.9.0]: https://github.com/facebook/react-native/releases/tag/v0.9.0-rc
   // [controlled component]: https://facebook.github.io/react/docs/forms.html#controlled-components
   withDefaultValue(defaultValue) {
-    const propName = Textfield.propTypes.defaultValue ? 'defaultValue' : 'value';
+    const propName = Textfield.propTypes.defaultValue
+      ? "defaultValue"
+      : "value";
     this[propName] = defaultValue;
     return this;
   }
@@ -679,14 +689,17 @@ class TextfieldBuilder extends Builder {
 
   build() {
     const BuiltTextfield = class extends Textfield {};
-    BuiltTextfield.defaultProps = Object.assign({}, Textfield.defaultProps, this.toProps());
+    BuiltTextfield.defaultProps = Object.assign(
+      {},
+      Textfield.defaultProps,
+      this.toProps()
+    );
     return BuiltTextfield;
   }
 }
 
 // define builder method for each prop
 TextfieldBuilder.defineProps(Textfield.propTypes);
-
 
 // ----------
 // ## <section id="builders">Built-in builders</section>
@@ -698,7 +711,6 @@ function textfield() {
 function textfieldWithFloatingLabel() {
   return textfield().withFloatingLabelEnabled(true);
 }
-
 
 // ## Public interface
 module.exports = Textfield;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-kit",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Bringing Material Design to React Native",
   "main": "lib/index.js",
   "author": "Yingxin Wu <yingxinwu.g@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-kit",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Bringing Material Design to React Native",
   "main": "lib/index.js",
   "author": "Yingxin Wu <yingxinwu.g@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-kit",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Bringing Material Design to React Native",
   "main": "lib/index.js",
   "author": "Yingxin Wu <yingxinwu.g@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-kit",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Bringing Material Design to React Native",
   "main": "lib/index.js",
   "author": "Yingxin Wu <yingxinwu.g@gmail.com>",


### PR DESCRIPTION
Step to reproduce issue:
- using JSX to create a component with `floatingLabelEnabled` and `multiline` mode.
- Focus to textfield
- type something
- clear text
- blur textfield 
=> Place holder is gone in iOS. Seem if you set placeholder is empty it's not re-render again. 

Solution: set placeholder is ' ' (a space) instead of empty string