### PR TITLE
Fix for issue #365

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,4 +18,4 @@
 # org.gradle.parallel=true
 
 android.useDeprecatedNdk=true
-com.android.build.threadPoolSize=4
+android.threadPoolSize=4


### PR DESCRIPTION
Fixes error when you upgrade Android Studio.

Error:The following project options are deprecated: com.android.build.threadPoolSize The com.android.build.threadPoolSize property has been replaced by android.threadPoolSize