### PR TITLE
com.android.build.threadPoolSize are deprecated.

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,4 +18,4 @@
 # org.gradle.parallel=true
 
 android.useDeprecatedNdk=true
-com.android.build.threadPoolSize=4
+android.threadPoolSize=4


### PR DESCRIPTION
com.android.build.threadPoolSize are deprecated. It has been replaced by android.threadPoolSize

Support gradle version >= 3