### PR TITLE
Use native driver in iOS spinner

### DIFF
--- a/lib/mdl/Spinner.ios.js
+++ b/lib/mdl/Spinner.ios.js
@@ -121,10 +121,12 @@ class Spinner extends Component {
         Animated.timing(this._animatedContainerAngle, {
           duration,
           toValue: 1,
+          useNativeDriver: true
         }),
         Animated.timing(this._animatedArcAngle, {
           duration,
           toValue: 1,
+          useNativeDriver: true
         }),
       ]).start(({ finished }) => finished && setImmediate(this._aniUpdateSpinner));
     });

--- a/lib/mdl/Spinner.ios.js
+++ b/lib/mdl/Spinner.ios.js
@@ -121,12 +121,12 @@ class Spinner extends Component {
         Animated.timing(this._animatedContainerAngle, {
           duration,
           toValue: 1,
-          useNativeDriver: true
+          useNativeDriver: true,
         }),
         Animated.timing(this._animatedArcAngle, {
           duration,
           toValue: 1,
-          useNativeDriver: true
+          useNativeDriver: true,
         }),
       ]).start(({ finished }) => finished && setImmediate(this._aniUpdateSpinner));
     });


### PR DESCRIPTION
Title pretty much says it all.

Currently spinner is dependent on the UI thread, making it loose its smoothness during heavy operations. Using the native driver remedies this.

The Android one is already a native component.