### PR TITLE
Expose react native text input clear method

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -356,6 +356,13 @@ class Textfield extends Component {
     }
   }
 
+  clear() {
+    if (this.refs.input) {
+      this.refs.input.clear();
+      this.bufferedValue = '';
+    }
+  }
+
   componentWillMount() {
     this.bufferedValue = this.props.value || this.props.text ||
     this.props.defaultValue;


### PR DESCRIPTION
## What does this PR Do?
- This PR exposes the React Native Text Input ```clear()``` method. #335 

## How can I use this?
- Just like ```this.ref.textfield.onBlur``` or ```this.ref.textfield.onFocus`` you can now use the reference to the textfield and call ```this.ref.textfield.clear()```