### PR TITLE
Fix "UIView+React.h" missing header error

### DIFF
--- a/iOS/RCTMaterialKit/MKTouchableManager.m
+++ b/iOS/RCTMaterialKit/MKTouchableManager.m
@@ -8,7 +8,7 @@
 
 #import <React/RCTViewManager.h>
 #import <React/RCTEventDispatcher.h>
-#import <UIView+React.h>
+#import <React/UIView+React.h>
 #import "MKTouchable.h"
 
 @interface MKTouchableManager : RCTViewManager <MKTouchableDelegate>

--- a/iOS/RCTMaterialKit/TickViewManager.m
+++ b/iOS/RCTMaterialKit/TickViewManager.m
@@ -7,7 +7,7 @@
 //
 
 #import <React/RCTViewManager.h>
-#import <UIView+React.h>
+#import <React/UIView+React.h>
 #import "TickView.h"
 
 @interface TickViewManager : RCTViewManager


### PR DESCRIPTION
Pull request #372 has an incorrect solution to this problem. The problem isn't double-quotes vs. angle brackets, it's that the header has actually moved location as of react-native 0.44.0: https://github.com/facebook/react-native/releases/tag/v0.40.0

Therefore, the correct solution is to use `#import <React/UIView+React.h>`, not `#import "UIView+React.h"`.