### PR TITLE
Fix for Checkbox not updating visual state, on iOS

### DIFF
--- a/src/mdl/Checkbox.tsx
+++ b/src/mdl/Checkbox.tsx
@@ -102,9 +102,11 @@ export default class Checkbox extends Component<CheckboxProps, CheckboxState> {
   // }
   
   // On iPhone X - iOS 12, at times the checkbox doesn't changes it's state. This 
-  // will fix that.
-  componentDidUpdate(prevProps: CheckboxProps) {
-    if (prevProps.checked !== this.props.checked){
+  // will fix that. EDIT : 29/03/2019 - Apparently the last one was only half a fix
+  // so added another condition to fix it.
+  componentDidUpdate(prevProps: CheckboxProps, prevState: CheckboxState) {
+    if (prevProps.checked !== this.props.checked &&
+        prevState.checked !== this.state.checked){
       this._initView(this.props.checked);
     }
   }


### PR DESCRIPTION
This fix addresses the issue when on devices like iPhone X running iOS 12, when we try to check the checkbox initially, it shows the ripple, and gives it's new state in code but visually it doesn't changes it's state. That is, it looks like it's not checked (whereas internally it is). So, this fix shall fix this inconsistency between internal state and visual state of this component.