### PR TITLE
Update ReactMaterialKitPackage.java

### DIFF
--- a/android/src/main/java/com/github/xinthink/rnmk/ReactMaterialKitPackage.java
+++ b/android/src/main/java/com/github/xinthink/rnmk/ReactMaterialKitPackage.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 public class ReactMaterialKitPackage implements ReactPackage {
 
-    @Override
+    
     public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
         return Collections.emptyList();
     }
@@ -27,7 +27,7 @@ public class ReactMaterialKitPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
+    
     public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
         return Arrays.<ViewManager>asList(
                 new MKTouchableManager(),


### PR DESCRIPTION
Solves this problem:

* What went wrong:
Execution failed for task ':react-native-material-kit:compileDebugJavaWithJavac'.

/node_modules/react-native-material-kit/android/src/main/java/com/github/xinthink/rnmk/ReactMaterialKitPackage.java:25: error: method does not override or implement a method from a supertype
    @Override
    ^